### PR TITLE
Adhere to Apple's CircleCI policies to fix broken builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,12 @@ jobs:
 
 workflows:
   build_and_test:
+    when:
+      matches:
+        # Only on branches approved by Apple CircleCI policy:
+        # https://app.circleci.com/settings/organization/github/apple/policies/baseline_apple
+        pattern: "^main|gh-readonly-queue/main/pr-\\d+-[0-9a-f]{40}.*$"
+        value: << pipeline.git.branch >>
     jobs:
       - code-quality
       - build-documentation-wheel
@@ -164,7 +170,34 @@ workflows:
             branches:
               only: main
 
-
+  build_and_test-pr:
+    when:
+      matches:
+        # PR builds need approval, as per Apple CircleCI policy:
+        # https://app.circleci.com/settings/organization/github/apple/policies/baseline_apple
+        pattern: "^pull/\\d+(/head)?$"
+        value: << pipeline.git.branch >>
+    jobs:
+      - hold:
+          type: approval
+      - code-quality:
+          requires:
+            - hold
+      - build-documentation-wheel:
+          requires:
+            - hold
+      - test-tf:
+          requires:
+            - hold
+      - test-pytorch:
+          requires:
+            - hold
+      - test-benchmarks:
+          requires:
+            - hold
+      - check-run-cifar10:
+          requires:
+            - hold
 
 
 


### PR DESCRIPTION
Apple org on CircleCI has added policies here https://app.circleci.com/settings/organization/github/apple/policies/baseline_apple

which results in you can only run CI on main repo on branches "^main|gh-readonly-queue/main/pr-\\d+-[0-9a-f]{40}.*$"
and PR builds need to be hold by approval.
Builds currently not running because of error message:
```
policy evaluation failed:
baseline_apple_requirements: workflow 'build_and_test' runs on unsafe branches and first job must be hold
```

I have tested this fix works on my personal fork:
![image](https://github.com/apple/pfl-research/assets/16865473/a2f8ddc8-5fae-4288-96af-e4b206c9ea8e)
