### PR TITLE
Fix check-run-lm CI 

### DIFF
--- a/benchmarks/utils/callback/pytorch.py
+++ b/benchmarks/utils/callback/pytorch.py
@@ -12,7 +12,8 @@ def get_polynomial_decay_schedule_with_warmup(optimizer,
     https://huggingface.co/transformers/v4.6.0/_modules/transformers/optimization.html#get_polynomial_decay_schedule_with_warmup """
 
     lr_init = optimizer.defaults["lr"]
-    assert lr_init > lr_end, f"lr_end ({lr_end}) must be be smaller than initial lr ({lr_init})"
+    assert lr_init >= lr_end, (f"lr_end ({lr_end}) must be be smaller than or "
+                               f"equal to initial lr ({lr_init})")
 
     def lr_lambda(current_step: int):
         if current_step < num_warmup_steps:


### PR DESCRIPTION
The central lr scheduler check is missing an equal sign.