### PR TITLE
Fixing broken links to point to github

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -53,7 +53,7 @@ There are multiple official benchmarks for `pfl` to simulate various scenarios, 
 ## Run distributed simulations
 
 Each benchmark can run in distributed mode with multiple cores, GPUs and machines.
-See the [distributed simulation guide](https://pages.github.apple.com/apple/pfl-research/tutorials/simulation_distributed.html) on how it works.
+See the [distributed simulation guide](https://apple.github.io/pfl-research/guides/simulation_distributed.html) on how it works.
 In summary, to quickly get started running distributed simulations:
 1. Install [Horovod](https://horovod.readthedocs.io/en/stable/install_include.html). We have a helper script [here](https://github.com/apple/pfl-research/blob/main/build_scripts/install_horovod.sh).
 2. Invoke your Python script with the `horovodrun` command. E.g. to run the same CIFAR10 training as described above in the quickstart, but train with 2 processes on the same machine, the command will look like this:

--- a/tutorials/Introduction to Federated Learning with CIFAR10.ipynb
+++ b/tutorials/Introduction to Federated Learning with CIFAR10.ipynb
@@ -156,7 +156,7 @@
    "source": [
     "As displayed above, the images are of dimensions `32x32` with `3` color channels and the labels are one-hot vectors `[0-9]`. Also, you can see that we exclude all but 2 classes, Airplane (0) and Bird (2), to make things simple for this tutorial.\n",
     "\n",
-    "As the data is not inherently split into real users, we need to use [ArtificialFederatedDataset](https://pages.github.apple.com/apple/pfl-research/reference/data.html#pfl.data.federated_dataset.ArtificialFederatedDataset) to sample datapoints to create artificial user datasets for federated learning, which in turn requires a function for sampling the length of a user dataset and the actual datapoints of this dataset.\n",
+    "As the data is not inherently split into real users, we need to use [ArtificialFederatedDataset](https://apple.github.io/pfl-research/reference/data.html#pfl.data.federated_dataset.ArtificialFederatedDataset) to sample datapoints to create artificial user datasets for federated learning, which in turn requires a function for sampling the length of a user dataset and the actual datapoints of this dataset.\n",
     "\n",
     "Firstly, we define a function which samples the length of a dataset from a Poisson distribution with mean 5:"
    ]
@@ -360,7 +360,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To train a model using `pfl`, a [Model](https://pages.github.apple.com/apple/pfl-research/reference/model.html#models) object must be instantiated for the Deep Learning framework in which the model was defined. A `pfl` Model acts as an adapter between the model of the Deep Learning framework and `pfl`. We use Keras with TensorFlow for this example.\n",
+    "To train a model using `pfl`, a [Model](https://apple.github.io/pfl-research/reference/model.html#models) object must be instantiated for the Deep Learning framework in which the model was defined. A `pfl` Model acts as an adapter between the model of the Deep Learning framework and `pfl`. We use Keras with TensorFlow for this example.\n",
     "\n",
     "The central optimizer is an input parameter to the model object. This optimizer is used when applying the aggregated model update to the central model."
    ]
@@ -401,9 +401,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Backend` is a component in `pfl` used to collect and average statistics from user devices. [SimulatedBackend](https://pages.github.apple.com/apple/pfl-research/reference/aggregate.html#pfl.aggregate.SimulatedBackend) provides simulation. For larger datasets or models, it also [supports distributed simulations](https://pages.github.apple.com/apple/pfl-research/tutorials/simulation_distributed.html) with multiple processes, GPUs and machines.\n",
+    "`Backend` is a component in `pfl` used to collect and average statistics from user devices. [SimulatedBackend](https://apple.github.io/pfl-research/reference/aggregate.html#pfl.aggregate.SimulatedBackend) provides simulation. For larger datasets or models, it also [supports distributed simulations](https://apple.github.io/pfl-research/tutorials/simulation_distributed.html) with multiple processes, GPUs and machines.\n",
     "\n",
-    "`pfl` provides various privacy mechanisms in [pfl.privacy](https://pages.github.apple.com/apple/pfl-research/reference/privacy.html#module-privacy).\n",
+    "`pfl` provides various privacy mechanisms in [pfl.privacy](https://apple.github.io/pfl-research/reference/privacy.html#module-privacy).\n",
     "These mechanisms are used to guarantee local and/or central differential privacy and are parameterized by `SimulatedBackend` in simulations.\n",
     "\n",
     "Below, we initialize `SimulatedBackend` with Gaussian Moments Accountant as the central differential privacy mechanism, which provides the minimum privacy guarantee required by most use-cases."
@@ -445,7 +445,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The main component of a `pfl` modeling setup is the algorithm. In this tutorial, we will be using the [Federated Averaging](https://arxiv.org/pdf/1602.05629.pdf) algorithm. `pfl` implements Federated Averaging using the class [FederatedAveraging](https://pages.github.apple.com/apple/pfl-research/reference/algorithm.html#pfl.algorithm.federated_averaging.FederatedAveraging).\n",
+    "The main component of a `pfl` modeling setup is the algorithm. In this tutorial, we will be using the [Federated Averaging](https://arxiv.org/pdf/1602.05629.pdf) algorithm. `pfl` implements Federated Averaging using the class [FederatedAveraging](https://apple.github.io/pfl-research/reference/algorithm.html#pfl.algorithm.federated_averaging.FederatedAveraging).\n",
     "\n",
     "Everything is tied together in the `run` method of an algorithm. This method requires the model, backend, optional callbacks, as well as hyperparameters, which depends on the model and algorithm combination. In this case, training a neural network with federated averaging requires a `NNTrainHyperParams` and `NNAlgorithmParams`.\n",
     "\n",


### PR DESCRIPTION
Some links point to internal apple GH enterprise pages which are not viewable by external folks. Fixing those in this PR.