### PR TITLE
Rename EMMGMMHyperParams to EMGMMHyperParams

### DIFF
--- a/pfl/algorithm/expectation_maximization_gmm.py
+++ b/pfl/algorithm/expectation_maximization_gmm.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class EMMGMMHyperParams(AlgorithmHyperParams):
+class EMGMMHyperParams(AlgorithmHyperParams):
     """
     Parameters for EM GMM algorithms.
 
@@ -113,7 +113,7 @@ def make_compute_new_num_components(
     return compute_new_num_components
 
 
-class ExpectationMaximizationGMM(FederatedAlgorithm[EMMGMMHyperParams,
+class ExpectationMaximizationGMM(FederatedAlgorithm[EMGMMHyperParams,
                                                     GMMHyperParams,
                                                     GaussianMixtureModel,
                                                     MappedVectorStatistics,
@@ -132,7 +132,7 @@ class ExpectationMaximizationGMM(FederatedAlgorithm[EMMGMMHyperParams,
         self,
         model: GaussianMixtureModel,
         iteration: int,
-        algorithm_params: EMMGMMHyperParams,
+        algorithm_params: EMGMMHyperParams,
         model_train_params: GMMHyperParams,
         model_eval_params: Optional[GMMHyperParams] = None,
     ) -> Tuple[Optional[Tuple[CentralContext, ...]], GaussianMixtureModel,

--- a/tests/algorithm/test_expectation_maximization_gmm.py
+++ b/tests/algorithm/test_expectation_maximization_gmm.py
@@ -6,7 +6,7 @@ import pytest
 
 from pfl.aggregate.base import Backend, get_total_weight_name
 from pfl.algorithm.expectation_maximization_gmm import (
-    EMMGMMHyperParams,
+    EMGMMHyperParams,
     ExpectationMaximizationGMM,
     make_compute_new_num_components,
 )
@@ -144,7 +144,7 @@ class TestExpectationMaximizationGMM:
             max_num_components=64,
             step_components=2)
 
-        algorithm_params = EMMGMMHyperParams(
+        algorithm_params = EMGMMHyperParams(
             central_num_iterations=central_num_iterations,
             evaluation_frequency=1,
             val_cohort_size=fixed_val_cohort_size,


### PR DESCRIPTION
This fixes what I believe to be a typo: `EMMGMMHyperParams` -> `EMGMMHyperParams`.

I believe that "EM" stands for "expectation–maximisation" and that the extra "M" snuck in accidentally. (I imagine I did this back in the day.)

I have tested this somewhat.