### PR TITLE
set seeds for tf examples

### DIFF
--- a/benchmarks/image_classification/tf/train.py
+++ b/benchmarks/image_classification/tf/train.py
@@ -2,6 +2,7 @@
 import argparse
 import logging
 import os
+import random
 from uuid import uuid4
 
 import numpy as np
@@ -55,6 +56,8 @@ def main():
     argument_parser = add_model_arguments(argument_parser)
     arguments = argument_parser.parse_args()
 
+    os.environ['PYTHONHASHSEED'] = str(arguments.seed)
+    random.seed(arguments.seed)
     tf.random.set_seed(arguments.seed)
     np.random.seed(arguments.seed)
 

--- a/benchmarks/lm/tf/train.py
+++ b/benchmarks/lm/tf/train.py
@@ -2,6 +2,7 @@
 import argparse
 import logging
 import os
+import random
 from uuid import uuid4
 
 import numpy as np
@@ -58,6 +59,8 @@ def main():
     parser = add_weighting_arguments(parser)
     arguments = parser.parse_args()
 
+    os.environ['PYTHONHASHSEED'] = str(arguments.seed)
+    random.seed(arguments.seed)
     np.random.seed(arguments.seed)
     tf.random.set_seed(arguments.seed)
 


### PR DESCRIPTION
This should correctly set same parameters of models every run. this was causing degraded results in multi-process training