### PR TITLE
return local metadata from training

### DIFF
--- a/pfl/context.py
+++ b/pfl/context.py
@@ -8,6 +8,19 @@ from pfl.metrics import Metrics
 
 
 @dataclass(frozen=True)
+class LocalResultMetaData:
+    """
+    Data that is typically returned by a model's local optimization procedure,
+    e.g. ``PyTorchModel.do_multiple_epochs_of``. Can have useful information
+    needed by the algorithm.
+
+    :param num_steps:
+        The number of local steps taken during the local optimization procedure.
+    """
+    num_steps: int
+
+
+@dataclass(frozen=True)
 class UserContext:
     """
     Provides read-only information about the user. This is exposed to


### PR DESCRIPTION
to make the helper fn `do_multiple_epochs_of` more widely useful for other algorithms, return a new simple dataclass with any information we may want to propagate. Only number of local steps taken is known to be useful at this moment. 

rdar://124202046 