### PR TITLE
Improved greedy worker scheduling

### DIFF
--- a/benchmarks/dataset/argument_parsing.py
+++ b/benchmarks/dataset/argument_parsing.py
@@ -132,6 +132,20 @@ def add_dataset_arguments(
                             default=100,
                             help='Maximum number of images per user')
 
+        parser.add_argument('--scheduling_base_weight_multiplier',
+                            type=float,
+                            default=1.0,
+                            help=(
+                            'Figure 3b in pfl-research paper '
+                            'https://arxiv.org/abs/2404.06430 show adding a'
+                            'base value for each user\'s weight for scheduling '
+                            'in distributed simulations speeds up training. '
+                            'This parameter adds a '
+                            'multiplicative factor of the median user weight '
+                            'as base value. 0.0 means no base value added and '
+                            '~1.0 is the optimal value for the FLAIR benchmark '
+                            'according to Figure 3b (can be different for '
+                            'other setups).'))
     elif known_args.dataset == 'alpaca':
         parser = add_artificial_fed_dataset_arguments(parser)
 
@@ -289,6 +303,7 @@ def get_datasets(
             data_path=args.data_path,
             use_fine_grained_labels=args.use_fine_grained_labels,
             max_num_user_images=args.max_num_user_images,
+            scheduling_base_weight_multiplier=args.scheduling_base_weight_multiplier,
             numpy_to_tensor=numpy_to_tensor)
     elif args.dataset == 'flair_pytorch':
         from .flair import make_flair_pytorch_datasets

--- a/benchmarks/dataset/argument_parsing.py
+++ b/benchmarks/dataset/argument_parsing.py
@@ -132,20 +132,20 @@ def add_dataset_arguments(
                             default=100,
                             help='Maximum number of images per user')
 
-        parser.add_argument('--scheduling_base_weight_multiplier',
-                            type=float,
-                            default=1.0,
-                            help=(
-                            'Figure 3b in pfl-research paper '
-                            'https://arxiv.org/abs/2404.06430 show adding a'
-                            'base value for each user\'s weight for scheduling '
-                            'in distributed simulations speeds up training. '
-                            'This parameter adds a '
-                            'multiplicative factor of the median user weight '
-                            'as base value. 0.0 means no base value added and '
-                            '~1.0 is the optimal value for the FLAIR benchmark '
-                            'according to Figure 3b (can be different for '
-                            'other setups).'))
+        parser.add_argument(
+            '--scheduling_base_weight_multiplier',
+            type=float,
+            default=1.0,
+            help=('Figure 3b in pfl-research paper '
+                  'https://arxiv.org/abs/2404.06430 show adding a'
+                  'base value for each user\'s weight for scheduling '
+                  'in distributed simulations speeds up training. '
+                  'This parameter adds a '
+                  'multiplicative factor of the median user weight '
+                  'as base value. 0.0 means no base value added and '
+                  '~1.0 is the optimal value for the FLAIR benchmark '
+                  'according to Figure 3b (can be different for '
+                  'other setups).'))
     elif known_args.dataset == 'alpaca':
         parser = add_artificial_fed_dataset_arguments(parser)
 
@@ -303,7 +303,8 @@ def get_datasets(
             data_path=args.data_path,
             use_fine_grained_labels=args.use_fine_grained_labels,
             max_num_user_images=args.max_num_user_images,
-            scheduling_base_weight_multiplier=args.scheduling_base_weight_multiplier,
+            scheduling_base_weight_multiplier=args.
+            scheduling_base_weight_multiplier,
             numpy_to_tensor=numpy_to_tensor)
     elif args.dataset == 'flair_pytorch':
         from .flair import make_flair_pytorch_datasets

--- a/benchmarks/dataset/flair/__init__.py
+++ b/benchmarks/dataset/flair/__init__.py
@@ -25,7 +25,7 @@ def get_central_data_and_metadata(data_path: str,
 
 def make_flair_datasets(data_path: str, use_fine_grained_labels: bool,
                         max_num_user_images: int,
-                        scheduling_base_weight_multiplier: int,
+                        scheduling_base_weight_multiplier: float,
                         numpy_to_tensor: Callable):
     """
     Create a train and val ``FederatedDataset`` as well as a

--- a/benchmarks/dataset/flair/__init__.py
+++ b/benchmarks/dataset/flair/__init__.py
@@ -24,7 +24,7 @@ def get_central_data_and_metadata(data_path: str,
 
 
 def make_flair_datasets(data_path: str, use_fine_grained_labels: bool,
-                        max_num_user_images: int, 
+                        max_num_user_images: int,
                         scheduling_base_weight_multiplier: int,
                         numpy_to_tensor: Callable):
     """
@@ -35,13 +35,10 @@ def make_flair_datasets(data_path: str, use_fine_grained_labels: bool,
 
     training_federated_dataset = make_federated_dataset(
         data_path, 'train', use_fine_grained_labels, max_num_user_images,
-        scheduling_base_weight_multiplier,
-        numpy_to_tensor)
-    val_federated_dataset = make_federated_dataset(data_path, 'val',
-                                                   use_fine_grained_labels,
-                                                   max_num_user_images,
-                                                   scheduling_base_weight_multiplier,
-                                                   numpy_to_tensor)
+        scheduling_base_weight_multiplier, numpy_to_tensor)
+    val_federated_dataset = make_federated_dataset(
+        data_path, 'val', use_fine_grained_labels, max_num_user_images,
+        scheduling_base_weight_multiplier, numpy_to_tensor)
 
     central_data, metadata = get_central_data_and_metadata(
         data_path, use_fine_grained_labels)

--- a/benchmarks/dataset/flair/__init__.py
+++ b/benchmarks/dataset/flair/__init__.py
@@ -24,7 +24,9 @@ def get_central_data_and_metadata(data_path: str,
 
 
 def make_flair_datasets(data_path: str, use_fine_grained_labels: bool,
-                        max_num_user_images: int, numpy_to_tensor: Callable):
+                        max_num_user_images: int, 
+                        scheduling_base_weight_multiplier: int,
+                        numpy_to_tensor: Callable):
     """
     Create a train and val ``FederatedDataset`` as well as a
     central dataset from the FLAIR dataset.
@@ -33,10 +35,12 @@ def make_flair_datasets(data_path: str, use_fine_grained_labels: bool,
 
     training_federated_dataset = make_federated_dataset(
         data_path, 'train', use_fine_grained_labels, max_num_user_images,
+        scheduling_base_weight_multiplier,
         numpy_to_tensor)
     val_federated_dataset = make_federated_dataset(data_path, 'val',
                                                    use_fine_grained_labels,
                                                    max_num_user_images,
+                                                   scheduling_base_weight_multiplier,
                                                    numpy_to_tensor)
 
     central_data, metadata = get_central_data_and_metadata(

--- a/benchmarks/dataset/flair/numpy.py
+++ b/benchmarks/dataset/flair/numpy.py
@@ -20,7 +20,7 @@ def make_federated_dataset(
         partition: str,
         use_fine_grained_labels: bool,
         max_num_user_images: int,
-        scheduling_base_weight_multiplier: int = 1,
+        scheduling_base_weight_multiplier: float = 1.,
         numpy_to_tensor: Callable = lambda x: x) -> FederatedDataset:
     """
     Create federated dataset from the flair dataset, to use in simulations.
@@ -35,6 +35,16 @@ def make_federated_dataset(
         Whether to use fine-grained label taxonomy.
     :param max_num_user_images:
         Maximum number of images each user can have.
+    :param scheduling_base_weight_multiplier:
+        The number of datapoints per user is used as a weight to greedily
+        schedule users in distributed simulations. Figure 3b in pfl-research
+        paper https://arxiv.org/abs/2404.06430 show adding a base value for
+        each user\'s weight for scheduling in distributed simulations
+        speeds up training.
+        This parameter adds a multiplicative factor of the median user weight
+        as base value. 0.0 means no base value added and ~1.0 is the optimal
+        value for the FLAIR benchmark according to Figure 3b (can be different
+        for other setups.
     :param numpy_to_tensor:
         Function that convert numpy array to ML framework tensor.
     :return:

--- a/benchmarks/dataset/flair/numpy.py
+++ b/benchmarks/dataset/flair/numpy.py
@@ -1,5 +1,6 @@
 # Copyright © 2023-2024 Apple Inc.
 
+import logging
 from typing import Callable
 
 import h5py
@@ -11,12 +12,14 @@ from pfl.data.sampling import get_data_sampler, get_user_sampler
 
 from .common import get_label_mapping, get_multi_hot_targets, get_user_num_images
 
+logger = logging.getLogger(name=__name__)
 
 def make_federated_dataset(
         hdf5_path: str,
         partition: str,
         use_fine_grained_labels: bool,
         max_num_user_images: int,
+        scheduling_base_weight_multiplier: int = 1,
         numpy_to_tensor: Callable = lambda x: x) -> FederatedDataset:
     """
     Create federated dataset from the flair dataset, to use in simulations.
@@ -37,8 +40,13 @@ def make_federated_dataset(
         Federated dataset from the HDF5 data file.
     """
     num_classes = len(get_label_mapping(hdf5_path, use_fine_grained_labels))
-    user_num_images = get_user_num_images(hdf5_path, partition)
-    user_ids = sorted(user_num_images.keys())
+    user_id_to_weight = {k:min(v,max_num_user_images) for k,v in get_user_num_images(hdf5_path, partition).items()}
+    median_datapoints = np.median(list(user_id_to_weight.values()))
+    base_value = scheduling_base_weight_multiplier*median_datapoints
+    logger.info(f'User mean datapoints: {np.mean(list(user_id_to_weight.values()))}, median datapoints: {median_datapoints}, base_value: {base_value}')
+    user_id_to_weight = {k:v + base_value for k,v in user_id_to_weight.items()}
+
+    user_ids = sorted(user_id_to_weight.keys())
     sampler = get_user_sampler('random', user_ids)
 
     def make_dataset_fn(user_id):
@@ -59,7 +67,7 @@ def make_federated_dataset(
 
     return FederatedDataset(make_dataset_fn,
                             sampler,
-                            user_id_to_weight=user_num_images)
+                            user_id_to_weight=user_id_to_weight)
 
 
 def make_artificial_federated_dataset(

--- a/benchmarks/dataset/flair/numpy.py
+++ b/benchmarks/dataset/flair/numpy.py
@@ -14,6 +14,7 @@ from .common import get_label_mapping, get_multi_hot_targets, get_user_num_image
 
 logger = logging.getLogger(name=__name__)
 
+
 def make_federated_dataset(
         hdf5_path: str,
         partition: str,
@@ -40,11 +41,19 @@ def make_federated_dataset(
         Federated dataset from the HDF5 data file.
     """
     num_classes = len(get_label_mapping(hdf5_path, use_fine_grained_labels))
-    user_id_to_weight = {k:min(v,max_num_user_images) for k,v in get_user_num_images(hdf5_path, partition).items()}
+    user_id_to_weight = {
+        k: min(v, max_num_user_images)
+        for k, v in get_user_num_images(hdf5_path, partition).items()
+    }
     median_datapoints = np.median(list(user_id_to_weight.values()))
-    base_value = scheduling_base_weight_multiplier*median_datapoints
-    logger.info(f'User mean datapoints: {np.mean(list(user_id_to_weight.values()))}, median datapoints: {median_datapoints}, base_value: {base_value}')
-    user_id_to_weight = {k:v + base_value for k,v in user_id_to_weight.items()}
+    base_value = scheduling_base_weight_multiplier * median_datapoints
+    logger.info(
+        f'User mean datapoints: {np.mean(list(user_id_to_weight.values()))}, median datapoints: {median_datapoints}, base_value: {base_value}'
+    )
+    user_id_to_weight = {
+        k: v + base_value
+        for k, v in user_id_to_weight.items()
+    }
 
     user_ids = sorted(user_id_to_weight.keys())
     sampler = get_user_sampler('random', user_ids)

--- a/benchmarks/flair/configs/baseline.yaml
+++ b/benchmarks/flair/configs/baseline.yaml
@@ -25,6 +25,7 @@ evaluation_frequency: 20
 central_eval_batch_size: 512
 pretrained: true
 #save_model_path: './checkpoints'
+scheduling_base_weight_multiplier: 1.0
 
 # Simulate I.I.D. data by ignoring user ID
 # - dataset: flair_iid

--- a/pfl/data/federated_dataset.py
+++ b/pfl/data/federated_dataset.py
@@ -142,8 +142,7 @@ class _SortedCohortSampler:
 
     def __iter__(self):
         while True:
-            for sample in self._samples_q.get():
-                yield sample
+            yield from self._samples_q.get()
 
     def set_cohort_size(self, cohort_size):
         self._cohort_request_q.put(cohort_size)

--- a/pfl/data/federated_dataset.py
+++ b/pfl/data/federated_dataset.py
@@ -49,8 +49,9 @@ def _distributed_sampler(sampler, get_seed, rank, world_size):
         yield users_all_workers[rank], seeds_all_workers[rank]
 
 
-def _sorted_cohort_subprocess(q_send, q_request, sampler, seed_sampler, rank,
-                              world_size, user_id_to_weight):
+def _sorted_cohort_subprocess(q_send, q_request, q_send_num, sampler,
+                              seed_sampler, rank, world_size,
+                              user_id_to_weight):
     cache = []
     cohort_size = None
     cache_size = _INITIAL_USER_SAMPLES_CACHE_SIZE
@@ -68,15 +69,26 @@ def _sorted_cohort_subprocess(q_send, q_request, sampler, seed_sampler, rank,
         if cohort_size is not None and len(cache) > cohort_size:
             # Perform request
             cohort_samples = cache[:cohort_size]
-            if user_id_to_weight is not None:
-                cohort_samples = sorted(
-                    cohort_samples,
-                    key=lambda tup: user_id_to_weight[tup[0]],
-                    reverse=True)
-            q_send.put(cohort_samples)
+            cohort_samples = sorted(cohort_samples,
+                                    key=lambda tup: user_id_to_weight[tup[0]],
+                                    reverse=True)
 
+            # This optimization procedure should be deterministic
+            # across all worker processes.
+            worker_samples = [[] for _ in range(world_size)]
+            worker_total_weight = np.zeros(world_size)
+            for sample in cohort_samples:
+                # Add user to worker with the minimum load.
+                min_worker_index = np.argmin(worker_total_weight)
+                worker_samples[min_worker_index].append(sample)
+                worker_total_weight[min_worker_index] += user_id_to_weight[
+                    sample[0]]
+
+            q_send_num.put(len(worker_samples[rank]))
+            q_send.put(worker_samples[rank])
             cache = cache[cohort_size:]
             cohort_size = None
+
         # Check if the queue is full
         if len(cache) < cache_size:
             # Generate multiple samples at a time
@@ -119,21 +131,23 @@ class _SortedCohortSampler:
 
         self._samples_q = mp.Queue()
         self._cohort_request_q = mp.Queue()
+        self._cohort_num_response_q = mp.Queue()
         self._sample_process = mp.Process(
             target=_sorted_cohort_subprocess,
-            args=(self._samples_q, self._cohort_request_q, sampler,
-                  seed_sampler, rank, world_size, user_id_to_weight))
+            args=(self._samples_q, self._cohort_request_q,
+                  self._cohort_num_response_q, sampler, seed_sampler, rank,
+                  world_size, user_id_to_weight))
         self._sample_process.start()
         atexit.register(self.__del__)
 
     def __iter__(self):
         while True:
-            for i, sample in enumerate(self._samples_q.get()):
-                if i % self._world_size == self._rank:
-                    yield sample
+            for sample in self._samples_q.get():
+                yield sample
 
     def set_cohort_size(self, cohort_size):
         self._cohort_request_q.put(cohort_size)
+        return self._cohort_num_response_q.get()
 
     def __del__(self):
         self._samples_q.close()
@@ -353,10 +367,12 @@ class FederatedDataset(FederatedDatasetBase):
 
     def _try_set_cohort_size(self, cohort_size: int):
         # Doesn't need a cohort to be set, can continue.
+        worker_cohort_size = None
         with contextlib.suppress(AttributeError):
             # pytype: disable=attribute-error
-            self._sample_fn.set_cohort_size(cohort_size)
+            worker_cohort_size = self._sample_fn.set_cohort_size(cohort_size)
             # pytype: enable=attribute-error
+        return worker_cohort_size
 
     def __next__(self) -> Tuple[AbstractDataset, int]:
         # Each worker will make a dataset with its own sampled user.
@@ -429,12 +445,18 @@ class FederatedDataset(FederatedDatasetBase):
 
     def get_cohort(self,
                    cohort_size: int) -> Iterable[Tuple[AbstractDataset, int]]:
-        self._try_set_cohort_size(cohort_size)
-        for i in range(cohort_size):
-            if (i % get_ops().distributed.world_size
-                ) == get_ops().distributed.global_rank:
-                user_ids, seed = next(self.sampler)
-                yield self.make_dataset_fn(user_ids), seed
+        # Set next cohort size for sampler if possible
+        worker_cohort_size = self._try_set_cohort_size(cohort_size)
+        if worker_cohort_size is None:
+            for i in range(cohort_size):
+                if (i % get_ops().distributed.world_size
+                    ) == get_ops().distributed.global_rank:
+                    user_id, seed = next(self.sampler)
+                    yield self.make_dataset_fn(user_id), seed
+        else:
+            for _ in range(worker_cohort_size):
+                user_id, seed = next(self.sampler)
+                yield self.make_dataset_fn(user_id), seed
 
 
 class FederatedDatasetMixture(FederatedDatasetBase):

--- a/tests/data/test_federated_dataset.py
+++ b/tests/data/test_federated_dataset.py
@@ -266,7 +266,7 @@ class TestFederatedDatasetMixture:
 @pytest.fixture
 def user_id_to_weight(request):
     if hasattr(request, 'param') and request.param:
-        return {i: i for i in range(100)}
+        return {i: i + 1 for i in range(100)}
     else:
         return None
 


### PR DESCRIPTION
Now assigns user to worker with the smallest accumulated user weight so far, like in a textbook greedy scheduling algorithm. Before, because of implementation issues, scheduling based on weight was done, but had to select the same number of users per process.