### PR TITLE
Update pytorch_ops distributed functionalities

### DIFF
--- a/pfl/internal/ops/pytorch_ops.py
+++ b/pfl/internal/ops/pytorch_ops.py
@@ -301,15 +301,14 @@ class PyTorchSeedScope:
 
     def __enter__(self):
         if self._seed is not None:
+            # Always save the random state for CPU
+            # Save random state for CUDA/MPS if they are available
             self._saved_state = {"cpu": torch.random.get_rng_state()}
-            try:
+            if torch.cuda.is_available():
                 self._saved_state["cuda"] = torch.cuda.get_rng_state_all()
-            except Exception as e:
-                logger.info(f"Failed to get cuda rng state: {e}")
-            try:
+            if (hasattr(torch.backends, 'mps')
+                    and torch.backends.mps.is_available()):
                 self._saved_state["mps"] = torch.mps.get_rng_state()
-            except Exception as e:
-                logger.info(f"Failed to get mps rng state: {e}")
             torch.random.manual_seed(self._seed)
 
     def __exit__(self, *args):


### PR DESCRIPTION
Updated a few functionalities in pytorch_ops distributed

1. Do not call `torch.cuda.set_device` if `CUDA_VISIBLE_DEVICES` is set in env.
2. Improve `PyTorchSeedScope` for non-cpu random states
3. Added horovod-compatible `Barrier` to mimic https://pytorch.org/docs/stable/distributed.html#torch.distributed.barrier