### PR TITLE
Remove affiliation for Rogier but add Orcid id

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,7 +16,7 @@ authors:
     affiliation: Apple
   - given-names: Rogier
     family-names: van Dalen
-    affiliation: Apple
+    orcid: "https://orcid.org/0000-0002-9603-5771"
   - given-names: Martin
     family-names: Pelikan
     affiliation: Apple
@@ -53,7 +53,7 @@ preferred-citation:
     affiliation: Apple
   - given-names: Rogier
     family-names: van Dalen
-    affiliation: Apple
+    orcid: "https://orcid.org/0000-0002-9603-5771"
   - given-names: Martin
     family-names: Pelikan
     affiliation: Apple


### PR DESCRIPTION
In `CITATION.cff`, my affiliation is down as "Apple" but I don't think that's correct, and it doesn't correspond to the paper. Instead, I've got an ORCID id to offer. This follows the citation file format at https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionspersonorcid