### PR TITLE
Fixes for when algorithm's state is restored with saveable

### DIFF
--- a/pfl/algorithm/base.py
+++ b/pfl/algorithm/base.py
@@ -245,6 +245,7 @@ class FederatedAlgorithm(Saveable,
 
         """
         self._current_central_iteration = 0
+        has_reported_on_train_metrics = False
         should_stop = False
         callbacks = list(callbacks or [])
         default_callbacks = get_platform().get_default_callbacks()
@@ -276,8 +277,9 @@ class FederatedAlgorithm(Saveable,
             else:
                 central_contexts = new_central_contexts
 
-            if self._current_central_iteration == 0:
+            if not has_reported_on_train_metrics:
                 all_metrics |= on_train_metrics
+                has_reported_on_train_metrics = True
 
             # Step 2
             # Get aggregated model updates and

--- a/pfl/callback.py
+++ b/pfl/callback.py
@@ -132,12 +132,14 @@ class RestoreTrainingCallback(TrainingProcessCallback):
                     'RestoreTrainingRunCallback - Restored checkpoint for %s',
                     saveable)
                 num_components_restored += 1
-        return Metrics([(StringMetricName('restored components'), num_components_restored)])
+        return Metrics([(StringMetricName('restored components'),
+                         num_components_restored)])
 
     def after_central_iteration(
             self, aggregate_metrics: Metrics, model: ModelType, *,
             central_iteration: int) -> Tuple[bool, Metrics]:
-        if (central_iteration % self._checkpoint_frequency == 0 and get_ops().distributed.local_rank == 0):
+        if (central_iteration % self._checkpoint_frequency == 0
+                and get_ops().distributed.local_rank == 0):
             for saveable, checkpoint_dir in zip(self._saveables,
                                                 self._checkpoint_dirs):
                 saveable.save(checkpoint_dir)

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -105,7 +105,7 @@ class TestRestoreTrainingCallback:
                                          mock_model,
                                          central_iteration=2)
         callback.on_train_begin(model=mock_model)
-        assert algorithm._current_central_iteration == 3
+        assert algorithm._current_central_iteration == 2
         mock_saveable.load.assert_called_once_with(str(tmp_path))
 
 


### PR DESCRIPTION
always include on_train_metrics first iteration. TrackBestOverallMetrics crashes if first iteration was not iteration 0.