### PR TITLE
Joint mechanisms

### DIFF
--- a/docs/source/reference/privacy.rst
+++ b/docs/source/reference/privacy.rst
@@ -28,6 +28,9 @@ Privacy mechanisms
 .. automodule:: pfl.privacy.ftrl_mechanism
    :members:
 
+.. automodule:: pfl.privacy.joint_mechanism
+   :members:
+
 Privacy accountants
 -------------------
 

--- a/pfl/privacy/joint_mechanism.py
+++ b/pfl/privacy/joint_mechanism.py
@@ -17,39 +17,28 @@ from .privacy_mechanism import CentrallyApplicablePrivacyMechanism, PrivacyMecha
 from .privacy_snr import SNRMetric
 
 
-def check_if_partition(full_list: Set[str], partition: List[Set[str]]):
+def check_if_partition(full_set: Set[str], partition: List[Set[str]]):
     """
     Checks if each element of full_list appears in exactly one of
-    the lists in partition
+    the sets in partition
     """
-    full_set = set(full_list)
-    size_of_partition = 0
-    for l in partition:
-        size_of_partition += len(l)
-        for s in l:
-            if s not in full_set:
-                # partition contains an element not in full_list
-                return False
+    partition_union: Set = set()
+    partition_size = 0
+    for s in partition:
+        partition_union = partition_union.union(s)
+        partition_size += len(s)
 
-    if not size_of_partition == len(full_set):
-        # partition is missing an element
-        return False
-
-    return True
-
-
-
-
+    return (partition_union == full_set) and (partition_size == len(full_set))
 
 
 class JointMechanism(CentrallyApplicablePrivacyMechanism):
     """
     Constructs a new CentrallyApplicablePrivacyMechanism from existing ones.
     Each existing mechanism is applied to a disjoint subset of the client
-    statistic keys. As such JointMechanism can only be applied to client
+    statistics keys. As such JointMechanism can only be applied to client
     statistics of type MappedVectorStatistics.
 
-    :param mechanisms_to_keys:
+    :param mechanisms_and_keys:
         Dictionary in which each key is a name of a mechanism and each value
         is a tuple consisting of the corresponding CentrallyApplicablePrivacyMechanism
         and a list of keys specifying which portion of the user training statistics that
@@ -57,61 +46,87 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
         distinct for the purpose of naming the corresponding Metrics.
 
     """
-    def __init__(self, mechanisms_to_keys: Dict[str, Tuple[CentrallyApplicablePrivacyMechanism, List[str]]]):
-        if len(set(mechanisms_to_keys.keys())) < len(mechanisms_to_keys.keys()):
+
+    def __init__(
+        self,
+        mechanisms_and_keys: Dict[str,
+                                  Tuple[CentrallyApplicablePrivacyMechanism,
+                                        List[str]]]):
+        if len(set(mechanisms_and_keys.keys())) < len(
+                mechanisms_and_keys.keys()):
             raise ValueError('Mechanism names must be unique.')
-        self.mechanisms_to_keys = mechanisms_to_keys
+        self.mechanisms_and_keys = mechanisms_and_keys
 
     def constrain_sensitivity(
             self,
-            statistics: MappedVectorStatistics,
+            statistics: TrainingStatistics,
             name_formatting_fn=lambda n: StringMetricName(n),
-            seed: Optional[int] = None) -> Tuple[MappedVectorStatistics, Metrics]:
+            seed: Optional[int] = None) -> Tuple[TrainingStatistics, Metrics]:
 
+        if not check_if_partition(
+                set(statistics.keys()),
+            [set(keys) for _, keys in self.mechanisms_and_keys.values()]):
+            raise ValueError(
+                'Mechanism keys do not form a partition of the client statistics keys.'
+            )
 
-        if not check_if_partition(list(statistics.keys()), [keys for _, keys in self.mechanisms_to_keys.values()]):
-            raise ValueError('Mechanism keys do not form a partition of the client statistics.')
+        if not isinstance(statistics, MappedVectorStatistics):
+            raise ValueError(
+                'Statistics must be of type MappedVectorStatistics.')
 
-        clipped_statistics = MappedVectorStatistics(weight=statistics.weight)
         metrics = Metrics()
-        for mechanism_name, (mechanism, statistics_keys) in self.mechanisms_to_keys.items():
+        for mechanism_name, (
+                mechanism,
+                statistics_keys) in self.mechanisms_and_keys.items():
+
             def mechanism_name_formatting_fn(n, prefix=mechanism_name):
                 return name_formatting_fn(f'{prefix}: {n}')
 
-            sub_statistics = MappedVectorStatistics()
+            sub_statistics: MappedVectorStatistics = MappedVectorStatistics()
             for key in statistics_keys:
                 sub_statistics[key] = statistics[key]
-            clipped_sub_statistics, sub_metrics = mechanism.constrain_sensitivity(sub_statistics,
-                                                                                  mechanism_name_formatting_fn,
-                                                                                  seed)
+            clipped_sub_statistics, sub_metrics = mechanism.constrain_sensitivity(
+                sub_statistics, mechanism_name_formatting_fn, seed)
             for key in statistics_keys:
-                clipped_statistics[key] = clipped_sub_statistics[key]
+                statistics[key] = clipped_sub_statistics[key]
             metrics = metrics | sub_metrics
 
-        return clipped_statistics, metrics
+        return statistics, metrics
 
     def add_noise(
             self,
-            statistics: MappedVectorStatistics,
+            statistics: TrainingStatistics,
             cohort_size: int,
             name_formatting_fn=lambda n: StringMetricName(n),
-            seed: Optional[int] = None) -> Tuple[MappedVectorStatistics, Metrics]:
+            seed: Optional[int] = None) -> Tuple[TrainingStatistics, Metrics]:
 
-        noised_statistics = MappedVectorStatistics(weight=statistics.weight)
+        if not check_if_partition(
+                set(statistics.keys()),
+            [set(keys) for _, keys in self.mechanisms_and_keys.values()]):
+            raise ValueError(
+                'Mechanism keys do not form a partition of the client statistics keys.'
+            )
+
+        if not isinstance(statistics, MappedVectorStatistics):
+            raise ValueError(
+                'Statistics must be of type MappedVectorStatistics.')
+
         metrics = Metrics()
-        for mechanism_name, (mechanism, statistics_keys) in self.mechanisms_to_keys.items():
+        for mechanism_name, (
+                mechanism,
+                statistics_keys) in self.mechanisms_and_keys.items():
+
             def mechanism_name_formatting_fn(n, prefix=mechanism_name):
                 return name_formatting_fn(f'{prefix}: {n}')
 
-            sub_statistics = MappedVectorStatistics()
+            sub_statistics: MappedVectorStatistics = MappedVectorStatistics()
             for key in statistics_keys:
                 sub_statistics[key] = statistics[key]
-            noised_sub_statistics, sub_metrics = mechanism.add_noise(sub_statistics,
-                                                                     cohort_size,
-                                                                     mechanism_name_formatting_fn,
-                                                                     seed)
+            noised_sub_statistics, sub_metrics = mechanism.add_noise(
+                sub_statistics, cohort_size, mechanism_name_formatting_fn,
+                seed)
             for key in statistics_keys:
-                noised_statistics[key] = noised_sub_statistics[key]
+                statistics[key] = noised_sub_statistics[key]
             metrics = metrics | sub_metrics
 
-        return noised_statistics, metrics
+        return statistics, metrics

--- a/pfl/privacy/joint_mechanism.py
+++ b/pfl/privacy/joint_mechanism.py
@@ -1,0 +1,117 @@
+# Copyright © 2023-2024 Apple Inc.
+'''
+Joint mechanism for combining multiple mechanisms into one.
+'''
+
+from typing import Dict, List, Optional, Set, Tuple
+
+from pfl.hyperparam import HyperParamClsOrFloat, get_param_value
+from pfl.internal.ops.selector import get_default_framework_module as get_ops
+from pfl.metrics import Metrics, StringMetricName, Weighted
+from pfl.stats import MappedVectorStatistics, TrainingStatistics
+
+from . import compute_parameters
+from .approximate_mechanism import SquaredErrorLocalPrivacyMechanism
+from .privacy_accountant import PrivacyAccountant
+from .privacy_mechanism import CentrallyApplicablePrivacyMechanism, PrivacyMechanism
+from .privacy_snr import SNRMetric
+
+
+def check_if_partition(full_list: Set[str], partition: List[Set[str]]):
+    """
+    Checks if each element of full_list appears in exactly one of
+    the lists in partition
+    """
+    full_set = set(full_list)
+    size_of_partition = 0
+    for l in partition:
+        size_of_partition += len(l)
+        for s in l:
+            if s not in full_set:
+                # partition contains an element not in full_list
+                return False
+
+    if not size_of_partition == len(full_set):
+        # partition is missing an element
+        return False
+
+    return True
+
+
+
+
+
+
+class JointMechanism(CentrallyApplicablePrivacyMechanism):
+    """
+    Constructs a new CentrallyApplicablePrivacyMechanism from existing ones.
+    Each existing mechanism is applied to a disjoint subset of the client
+    statistic keys. As such JointMechanism can only be applied to client
+    statistics of type MappedVectorStatistics.
+
+    :param mechanisms_to_keys:
+        Dictionary in which each key is a name of a mechanism and each value
+        is a tuple consisting of the corresponding CentrallyApplicablePrivacyMechanism
+        and a list of keys specifying which portion of the user training statistics that
+        mechanism should be applied to. Note the names of each of the mechanisms must be
+        distinct for the purpose of naming the corresponding Metrics.
+
+    """
+    def __init__(self, mechanisms_to_keys: Dict[str, Tuple[CentrallyApplicablePrivacyMechanism, List[str]]]):
+        if len(set(mechanisms_to_keys.keys())) < len(mechanisms_to_keys.keys()):
+            raise ValueError('Mechanism names must be unique.')
+        self.mechanisms_to_keys = mechanisms_to_keys
+
+    def constrain_sensitivity(
+            self,
+            statistics: MappedVectorStatistics,
+            name_formatting_fn=lambda n: StringMetricName(n),
+            seed: Optional[int] = None) -> Tuple[MappedVectorStatistics, Metrics]:
+
+
+        if not check_if_partition(list(statistics.keys()), [keys for _, keys in self.mechanisms_to_keys.values()]):
+            raise ValueError('Mechanism keys do not form a partition of the client statistics.')
+
+        clipped_statistics = MappedVectorStatistics(weight=statistics.weight)
+        metrics = Metrics()
+        for mechanism_name, (mechanism, statistics_keys) in self.mechanisms_to_keys.items():
+            def mechanism_name_formatting_fn(n, prefix=mechanism_name):
+                return name_formatting_fn(f'{prefix}: {n}')
+
+            sub_statistics = MappedVectorStatistics()
+            for key in statistics_keys:
+                sub_statistics[key] = statistics[key]
+            clipped_sub_statistics, sub_metrics = mechanism.constrain_sensitivity(sub_statistics,
+                                                                                  mechanism_name_formatting_fn,
+                                                                                  seed)
+            for key in statistics_keys:
+                clipped_statistics[key] = clipped_sub_statistics[key]
+            metrics = metrics | sub_metrics
+
+        return clipped_statistics, metrics
+
+    def add_noise(
+            self,
+            statistics: MappedVectorStatistics,
+            cohort_size: int,
+            name_formatting_fn=lambda n: StringMetricName(n),
+            seed: Optional[int] = None) -> Tuple[MappedVectorStatistics, Metrics]:
+
+        noised_statistics = MappedVectorStatistics(weight=statistics.weight)
+        metrics = Metrics()
+        for mechanism_name, (mechanism, statistics_keys) in self.mechanisms_to_keys.items():
+            def mechanism_name_formatting_fn(n, prefix=mechanism_name):
+                return name_formatting_fn(f'{prefix}: {n}')
+
+            sub_statistics = MappedVectorStatistics()
+            for key in statistics_keys:
+                sub_statistics[key] = statistics[key]
+            noised_sub_statistics, sub_metrics = mechanism.add_noise(sub_statistics,
+                                                                     cohort_size,
+                                                                     mechanism_name_formatting_fn,
+                                                                     seed)
+            for key in statistics_keys:
+                noised_statistics[key] = noised_sub_statistics[key]
+            metrics = metrics | sub_metrics
+
+        return noised_statistics, metrics

--- a/pfl/privacy/joint_mechanism.py
+++ b/pfl/privacy/joint_mechanism.py
@@ -58,7 +58,7 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
             seed: Optional[int] = None) -> Tuple[TrainingStatistics, Metrics]:
 
         if not isinstance(statistics, MappedVectorStatistics):
-            raise ValueError(
+            raise TypeError(
                 'Statistics must be of type MappedVectorStatistics.')
 
         if not check_if_partition(
@@ -96,7 +96,7 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
             seed: Optional[int] = None) -> Tuple[TrainingStatistics, Metrics]:
 
         if not isinstance(statistics, MappedVectorStatistics):
-            raise ValueError(
+            raise TypeError(
                 'Statistics must be of type MappedVectorStatistics.')
 
         if not check_if_partition(

--- a/pfl/privacy/joint_mechanism.py
+++ b/pfl/privacy/joint_mechanism.py
@@ -72,18 +72,18 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
                 else:
                     assert key[
                         -1] == '/', f"{key} does not appear as a key in the client statistics."
-                    for client_key in client_statistics_keys:
+                    for client_key in statistics:
                         if client_key.startswith(
                                 key):  # matches f'{key_prefix}/'
                             sub_statistics[client_key] = statistics[client_key]
-                            client_statistics_keys.remove(client_key)
+                            client_statistics_keys.discard(client_key)
 
             # Clip statistics using mechanism
             clipped_sub_statistics, sub_metrics = mechanism.constrain_sensitivity(
                 sub_statistics, mechanism_name_formatting_fn, seed)
 
             # Recombine clipped statistics and metrics
-            for key in sub_statistics.keys():
+            for key in clipped_sub_statistics:
                 clipped_statistics[key] = clipped_sub_statistics[key]
             metrics = metrics | sub_metrics
 
@@ -125,11 +125,11 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
                 else:
                     assert key[
                         -1] == '/', f"{key} does not appear as a key in the client statistics."
-                    for client_key in client_statistics_keys:
+                    for client_key in statistics:
                         if client_key.startswith(
                                 key):  # matches f'{key_prefix}/'
                             sub_statistics[client_key] = statistics[client_key]
-                            client_statistics_keys.remove(client_key)
+                            client_statistics_keys.discard(client_key)
 
             # Apply noise using mechanism
             noised_sub_statistics, sub_metrics = mechanism.add_noise(
@@ -137,7 +137,7 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
                 seed)
 
             # Recombine noised statistics and metrics
-            for key in sub_statistics:
+            for key in noised_sub_statistics:
                 noised_statistics[key] = noised_sub_statistics[key]
             metrics = metrics | sub_metrics
 

--- a/pfl/privacy/joint_mechanism.py
+++ b/pfl/privacy/joint_mechanism.py
@@ -58,14 +58,14 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
         metrics = Metrics()
         client_statistics_keys = set(statistics.keys())
         for mechanism_name, (
-                mechanism, to_apply_keys) in self.mechanisms_and_keys.items():
+                mechanism, mechanism_keys) in self.mechanisms_and_keys.items():
 
             def mechanism_name_formatting_fn(n, prefix=mechanism_name):
                 return name_formatting_fn(f'{prefix} | {n}')
 
             # Extract client statistics keys that match the keys for current mechanism
             sub_statistics: MappedVectorStatistics = MappedVectorStatistics()
-            for key in to_apply_keys:
+            for key in mechanism_keys:
                 if key in client_statistics_keys:  # exact key name
                     sub_statistics[key] = statistics[key]
                     client_statistics_keys.remove(key)
@@ -111,14 +111,14 @@ class JointMechanism(CentrallyApplicablePrivacyMechanism):
         metrics = Metrics()
         client_statistics_keys = set(statistics.keys())
         for mechanism_name, (
-                mechanism, to_apply_keys) in self.mechanisms_and_keys.items():
+                mechanism, mechanism_keys) in self.mechanisms_and_keys.items():
 
             def mechanism_name_formatting_fn(n, prefix=mechanism_name):
                 return name_formatting_fn(f'{prefix} | {n}')
 
             # Extract client statistics keys that match the keys for current mechanism
             sub_statistics: MappedVectorStatistics = MappedVectorStatistics()
-            for key in to_apply_keys:
+            for key in mechanism_keys:
                 if key in client_statistics_keys:  # exact key name
                     sub_statistics[key] = statistics[key]
                     client_statistics_keys.remove(key)

--- a/tests/privacy/test_privacy_mechanism.py
+++ b/tests/privacy/test_privacy_mechanism.py
@@ -583,14 +583,14 @@ class TestMechanisms:
                               (clip_factors[n] * input_stats[n])),
                     axis=(1, 2)) for n in var_names
         ])
-        laplace_idxs = np.array([0, 1])
-        gaussian_idxs = np.array([3, 4])
-        idxs = np.hstack([laplace_idxs, gaussian_idxs])
+        laplace_idxs = [np.array([0]), np.array([1, 2])]
+        gaussian_idxs = [np.array([3]), np.array([4, 5])]
+        idxs = laplace_idxs + gaussian_idxs
 
         fourth_pow_deviation_arrays = np.hstack([
             np.mean(np.power(
                 noised_arrays[n] - (clip_factors[n] * input_stats[n]), 4),
-                    axis=(1, 2)) / np.square(square_deviation_arrays[idxs][i])
+                    axis=(1, 2)) / np.square(square_deviation_arrays[idxs[i]])
             for i, n in enumerate(var_names)
         ])
 

--- a/tests/privacy/test_privacy_mechanism.py
+++ b/tests/privacy/test_privacy_mechanism.py
@@ -20,6 +20,7 @@ from pfl.metrics import Metrics, get_overall_value
 from pfl.privacy import compute_parameters
 from pfl.privacy.approximate_mechanism import SquaredErrorLocalPrivacyMechanism
 from pfl.privacy.gaussian_mechanism import GaussianMechanism
+from pfl.privacy.joint_mechanism import JointMechanism
 from pfl.privacy.laplace_mechanism import LaplaceMechanism
 from pfl.privacy.privacy_mechanism import (
     CentrallyAppliedPrivacyMechanism,
@@ -27,7 +28,7 @@ from pfl.privacy.privacy_mechanism import (
     NormClippingOnly,
     PrivacyMetricName,
 )
-from pfl.stats import MappedVectorStatistics
+from pfl.stats import MappedVectorStatistics, WeightedStatistics
 
 # These fixtures set the internal framework module.
 framework_fixtures = [
@@ -484,3 +485,228 @@ class TestMechanisms:
                                  is_local_privacy=True)
         assert get_overall_value(
             metrics[name]) == pytest.approx(expected_clip_fraction)
+
+    @pytest.mark.parametrize('ops_module', framework_fixtures)
+    @pytest.mark.parametrize('set_seed', [False, True])
+    @pytest.mark.parametrize('laplace_norm_bound', [0.02, 6e6])
+    @pytest.mark.parametrize('gaussian_norm_bound,gaussian_noise_scale',
+                             [(0.02, 1.0), (6e6, 1.0), (0.5, 0.1)])
+    def test_joint_mechanism(self, laplace_norm_bound, gaussian_norm_bound,
+                             gaussian_noise_scale, set_seed, ops_module):
+        shapes = [(1, 20000, 40), (2, 14000, 56), (1, 20000, 10),
+                  (2, 14000, 14)]
+
+        first_mechanism_name = 'Laplace Mechanism'
+        laplace_mechanism = LaplaceMechanism(laplace_norm_bound, _epsilon)
+
+        # standard deviation of a Laplace distribution
+        b = laplace_norm_bound / _epsilon
+        sigma_laplace = np.sqrt(2 * b**2)
+
+        # kurtosis of a Laplace distribution
+        kurtosis_laplace = 3
+
+        second_mechanism_name = 'Gaussian Mechanism'
+        gaussian_mechanism, sigma_gaussian = self._single_iteration_sigma(
+            gaussian_norm_bound, gaussian_noise_scale)
+
+        # kurtosis of a Gaussian distribution
+        kurtosis_gaussian = 0
+
+        # values to compare tracked metrics with
+        expected_metrics = Metrics([
+            (PrivacyMetricName(
+                f'{first_mechanism_name}: Laplace DP noise scale',
+                is_local_privacy=True), b),
+            (PrivacyMetricName(f'{second_mechanism_name}: DP noise std. dev.',
+                               is_local_privacy=True), sigma_gaussian)
+        ])
+
+        mechanisms_and_keys = {
+            first_mechanism_name: (laplace_mechanism, ['0', '1']),
+            second_mechanism_name: (gaussian_mechanism, ['2', '3'])
+        }
+
+        joint_mechanism = JointMechanism(mechanisms_and_keys)
+
+        input_stats = self._get_values(shapes)
+        input_tensor_stats = self._to_tensor_stats(input_stats, ops_module)
+
+        var_names = ['0', '1', '2', '3']
+
+        input_stats_laplace = MappedVectorStatistics({
+            '0': input_stats['0'],
+            '1': input_stats['1']
+        })
+        input_stats_gaussian = MappedVectorStatistics({
+            '2': input_stats['2'],
+            '3': input_stats['3']
+        })
+
+        laplace_clip_factor, laplace_clipped_input_stats = self._get_norm_clipped_values(
+            self._compute_l1_norm(input_stats_laplace), input_stats_laplace,
+            laplace_norm_bound)
+
+        gaussian_clip_factor, gaussian_clipped_input_stats = self._get_norm_clipped_values(
+            self._compute_l2_norm(input_stats_gaussian), input_stats_gaussian,
+            gaussian_norm_bound)
+
+        clip_factors = dict(
+            zip(var_names, [
+                laplace_clip_factor, laplace_clip_factor, gaussian_clip_factor,
+                gaussian_clip_factor
+            ]))
+        clipped_input_stats = {
+            **laplace_clipped_input_stats,
+            **gaussian_clipped_input_stats
+        }
+        """
+        Compute statistics from one privatization.
+        The statistics are the means over all dimensions but the first,
+        for better statistical power.
+        """
+        seed = 0 if set_seed else None
+        noised_arrays, metrics = joint_mechanism.postprocess_one_user(
+            stats=input_tensor_stats, user_context=MagicMock(seed=seed))
+        noised_arrays = self._from_tensor_stats(noised_arrays, ops_module)
+
+        # arrays after adding noise should have same shape as before
+        for name in var_names:
+            assert input_stats[name].shape == noised_arrays[name].shape
+
+        # Calculate statistics for each row in first dimension.
+        noised_sum_arrays = np.hstack(
+            [np.mean(noised_arrays[name], axis=(1, 2)) for name in var_names])
+
+        square_deviation_arrays = np.hstack([
+            np.mean(np.square(noised_arrays[n] -
+                              (clip_factors[n] * input_stats[n])),
+                    axis=(1, 2)) for n in var_names
+        ])
+        laplace_idxs = np.array([0, 1])
+        gaussian_idxs = np.array([3, 4])
+        idxs = np.hstack([laplace_idxs, gaussian_idxs])
+
+        fourth_pow_deviation_arrays = np.hstack([
+            np.mean(np.power(
+                noised_arrays[n] - (clip_factors[n] * input_stats[n]), 4),
+                    axis=(1, 2)) / np.square(square_deviation_arrays[idxs][i])
+            for i, n in enumerate(var_names)
+        ])
+
+        # Test the metrics that are output.
+        # How often the norm was clipped is either nothing or all in this test.
+        expected_metrics[PrivacyMetricName(
+            f'{first_mechanism_name}: fraction of clipped norms',
+            is_local_privacy=True)] = int(laplace_clip_factor < 1)
+        expected_metrics[PrivacyMetricName(
+            f'{first_mechanism_name}: norm before clipping',
+            is_local_privacy=True)] = self._compute_l1_norm(
+                input_stats_laplace)
+
+        expected_metrics[PrivacyMetricName(
+            f'{second_mechanism_name}: fraction of clipped norms',
+            is_local_privacy=True)] = int(gaussian_clip_factor < 1)
+        expected_metrics[PrivacyMetricName(
+            f'{second_mechanism_name}: norm before clipping',
+            is_local_privacy=True)] = self._compute_l2_norm(
+                input_stats_gaussian)
+
+        l1_name = PrivacyMetricName(f'{first_mechanism_name}: l1 norm bound',
+                                    is_local_privacy=True)
+        l2_name = PrivacyMetricName(f'{second_mechanism_name}: l2 norm bound',
+                                    is_local_privacy=True)
+
+        assert np.isclose(get_overall_value(metrics[l1_name]),
+                          laplace_norm_bound)
+        assert np.isclose(get_overall_value(metrics[l2_name]),
+                          gaussian_norm_bound)
+
+        for name, expected_metric in expected_metrics:
+            assert np.isclose(get_overall_value(metrics[name]),
+                              expected_metric,
+                              rtol=0.0001)
+
+        # convert from kurtosis to ex-kurtosis
+        kurtosis_values = fourth_pow_deviation_arrays - 3
+
+        flat_expected_values = np.hstack(
+            [clipped_input_stats[n][:, 0, 0].reshape(-1) for n in var_names])
+
+        # test moments
+        assert np.allclose(noised_sum_arrays[:3],
+                           flat_expected_values[:3],
+                           atol=sigma_laplace * 0.01)
+
+        assert np.allclose(square_deviation_arrays[:3],
+                           sigma_laplace**2,
+                           rtol=0.02)
+
+        assert np.allclose(noised_sum_arrays[3:],
+                           flat_expected_values[3:],
+                           atol=sigma_gaussian * 0.01)
+
+        assert np.allclose(square_deviation_arrays[3:],
+                           sigma_gaussian**2,
+                           rtol=0.02)
+
+        assert np.allclose(kurtosis_values[:3], kurtosis_laplace, atol=0.15)
+        assert np.allclose(kurtosis_values[3:], kurtosis_gaussian, atol=0.15)
+
+        if set_seed:
+            # Check that the same seed always yields the same results.
+            seed = 123
+            context = MagicMock(seed=None)
+            noise_1, _ = joint_mechanism.postprocess_one_user(
+                stats=input_tensor_stats, user_context=context)
+            noise_2, _ = joint_mechanism.postprocess_one_user(
+                stats=input_tensor_stats, user_context=context)
+
+            # With seed: the same results.
+            context = MagicMock(seed=seed)
+            seeded_noise_1, _ = joint_mechanism.postprocess_one_user(
+                stats=input_tensor_stats, user_context=context)
+            seeded_noise_2, _ = joint_mechanism.postprocess_one_user(
+                stats=input_tensor_stats, user_context=context)
+
+            noise_1 = self._from_tensor_stats(noise_1, ops_module)
+            noise_2 = self._from_tensor_stats(noise_2, ops_module)
+            seeded_noise_1 = self._from_tensor_stats(seeded_noise_1,
+                                                     ops_module)
+            seeded_noise_2 = self._from_tensor_stats(seeded_noise_2,
+                                                     ops_module)
+
+            for v1, v2 in zip(seeded_noise_1.get_weights()[1],
+                              seeded_noise_2.get_weights()[1]):
+                assert np.array_equal(v1, v2)
+
+            # Without seed: different results.
+            for v1, v2 in zip(noise_1.get_weights()[1],
+                              noise_2.get_weights()[1]):
+                assert (np.any(np.not_equal(v1, v2)))
+
+        # Apply joint mechanism when user statistics keys are missing
+        mechanisms_and_keys_missing_key = {
+            first_mechanism_name: (laplace_mechanism, ['0']),
+            second_mechanism_name: (gaussian_mechanism, ['2', '3'])
+        }
+
+        joint_mechanism = JointMechanism(mechanisms_and_keys_missing_key)
+
+        seed = 0 if set_seed else None
+        with pytest.raises(ValueError):
+            noised_arrays, metrics = joint_mechanism.postprocess_one_user(
+                stats=input_tensor_stats, user_context=MagicMock(seed=seed))
+
+        # Apply joint mechanism when too many keys are given to joint mechanism
+        mechanisms_and_keys_extra_key = {
+            first_mechanism_name: (laplace_mechanism, ['0', '1']),
+            second_mechanism_name: (gaussian_mechanism, ['2', '3', '4'])
+        }
+
+        joint_mechanism = JointMechanism(mechanisms_and_keys_extra_key)
+
+        seed = 0 if set_seed else None
+        with pytest.raises(ValueError):
+            noised_arrays, metrics = joint_mechanism.postprocess_one_user(
+                stats=input_tensor_stats, user_context=MagicMock(seed=seed))

--- a/tests/privacy/test_privacy_mechanism.py
+++ b/tests/privacy/test_privacy_mechanism.py
@@ -28,7 +28,7 @@ from pfl.privacy.privacy_mechanism import (
     NormClippingOnly,
     PrivacyMetricName,
 )
-from pfl.stats import MappedVectorStatistics, WeightedStatistics
+from pfl.stats import MappedVectorStatistics
 
 # These fixtures set the internal framework module.
 framework_fixtures = [

--- a/tests/privacy/test_privacy_mechanism.py
+++ b/tests/privacy/test_privacy_mechanism.py
@@ -529,12 +529,12 @@ class TestMechanisms:
             'laplace/subpath1', 'laplace/subpath2', 'gaussian_exact1',
             'gaussian_exact2', 'laplace_exact'
         ]
-        input_stats = MappedVectorStatistics(
-            dict(
-                zip(input_stats_keys, [
-                    np.ones(i + 1, dtype=np.float32)
-                    for i in range(len(input_stats_keys))
-                ])))
+        input_stats = MappedVectorStatistics(dict(
+            zip(input_stats_keys, [
+                np.ones(i + 1, dtype=np.float32)
+                for i in range(len(input_stats_keys))
+            ])),
+                                             weight=10)
         input_tensor_stats = self._to_tensor_stats(input_stats, ops_module)
 
         seed = 0


### PR DESCRIPTION
Implementing a privacy mechanism that takes in multiple existing mechanisms and applies them to disjoint portions of user statistics. This can be used in the situation that you want to make a multiple queries to a user simultaneously and each query should be noised differently e.g. because the queries have differing sensitivities or different noise distributions should be used.