### PR TITLE
Joint privacy accountant

### DIFF
--- a/docs/source/reference/privacy.rst
+++ b/docs/source/reference/privacy.rst
@@ -46,6 +46,21 @@ Privacy accountants
 .. autoclass:: pfl.privacy.RDPPrivacyAccountant
    :members:
 
+Joint Privacy accountants
+-------------------
+
+.. autoclass:: pfl.privacy.JointPrivacyAccountant
+   :members:
+
+.. autoclass:: pfl.privacy.JointPLDPrivacyAccountant
+   :members:
+
+.. autoclass:: pfl.privacy.JointPRVPrivacyAccountant
+   :members:
+
+.. autoclass:: pfl.privacy.JointRDPPrivacyAccountant
+   :members:
+
 DP with adaptive clipping
 -------------------------
 

--- a/docs/source/reference/privacy.rst
+++ b/docs/source/reference/privacy.rst
@@ -52,15 +52,6 @@ Joint Privacy accountants
 .. autoclass:: pfl.privacy.JointPrivacyAccountant
    :members:
 
-.. autoclass:: pfl.privacy.JointPLDPrivacyAccountant
-   :members:
-
-.. autoclass:: pfl.privacy.JointPRVPrivacyAccountant
-   :members:
-
-.. autoclass:: pfl.privacy.JointRDPPrivacyAccountant
-   :members:
-
 DP with adaptive clipping
 -------------------------
 

--- a/pfl/privacy/__init__.py
+++ b/pfl/privacy/__init__.py
@@ -1,7 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 from .gaussian_mechanism import GaussianMechanism
-from .joint_privacy_accountant import JointPLDPrivacyAccountant
+from .joint_privacy_accountant import JointPLDPrivacyAccountant, JointPRVPrivacyAccountant
 from .laplace_mechanism import LaplaceMechanism
 from .privacy_accountant import PLDPrivacyAccountant, PrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant
 from .privacy_mechanism import (

--- a/pfl/privacy/__init__.py
+++ b/pfl/privacy/__init__.py
@@ -1,7 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 from .gaussian_mechanism import GaussianMechanism
-from .joint_privacy_accountant import JointPLDPrivacyAccountant, JointPRVPrivacyAccountant, JointRDPPrivacyAccountant
+from .joint_privacy_accountant import JointPrivacyAccountant
 from .laplace_mechanism import LaplaceMechanism
 from .privacy_accountant import PLDPrivacyAccountant, PrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant
 from .privacy_mechanism import (

--- a/pfl/privacy/__init__.py
+++ b/pfl/privacy/__init__.py
@@ -1,6 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 from .gaussian_mechanism import GaussianMechanism
+from .joint_privacy_accountant import JointPLDPrivacyAccountant
 from .laplace_mechanism import LaplaceMechanism
 from .privacy_accountant import PLDPrivacyAccountant, PrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant
 from .privacy_mechanism import (

--- a/pfl/privacy/__init__.py
+++ b/pfl/privacy/__init__.py
@@ -1,7 +1,7 @@
 # Copyright © 2023-2024 Apple Inc.
 
 from .gaussian_mechanism import GaussianMechanism
-from .joint_privacy_accountant import JointPLDPrivacyAccountant, JointPRVPrivacyAccountant
+from .joint_privacy_accountant import JointPLDPrivacyAccountant, JointPRVPrivacyAccountant, JointRDPPrivacyAccountant
 from .laplace_mechanism import LaplaceMechanism
 from .privacy_accountant import PLDPrivacyAccountant, PrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant
 from .privacy_mechanism import (

--- a/pfl/privacy/joint_privacy_accountant.py
+++ b/pfl/privacy/joint_privacy_accountant.py
@@ -5,62 +5,83 @@ Joint privacy accountants for differential privacy with multiple mechanisms.
 
 import math
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional, Type
 
 from dp_accounting import dp_event
 from dp_accounting.pld import privacy_loss_distribution
 from dp_accounting.rdp import rdp_privacy_accountant
 from prv_accountant import LaplaceMechanism, PoissonSubsampledGaussianMechanism, PRVAccountant
 
-from .privacy_accountant import binary_search_function
-
-MIN_BOUND_NOISE_PARAMETER = 0
-MAX_BOUND_NOISE_PARAMETER = 100
-RTOL_NOISE_PARAMETER = 0.001
-CONFIDENCE_THRESHOLD_NOISE_PARAMETER = 1e-8
+from .privacy_accountant import (binary_search_function, MAX_BOUND_NOISE_PARAMETER, MIN_BOUND_NOISE_PARAMETER,
+                                 RTOL_NOISE_PARAMETER, CONFIDENCE_THRESHOLD_NOISE_PARAMETER,
+                                 PLDPrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant)
 
 MIN_BOUND_EPSILON = 0
 MAX_BOUND_EPSILON = 30
 RTOL_EPSILON = 0.001
 CONFIDENCE_THRESHOLD_EPSILON = 1e-8
 
+PFL_ACCOUNTANT_TYPE = PLDPrivacyAccountant | PRVPrivacyAccountant | RDPPrivacyAccountant
+
 
 @dataclass
 class JointPrivacyAccountant:
     """
-    Tracks the privacy loss over multiple composition steps with multiple
-    mechanisms simultaneously. Either two or three of the variables epsilon,
-    delta and noise_parameters must be defined.
-    If all three are defined a check will be performed to make sure a valid set of
-    variable values has been provided.
-    If two are defined, the remaining variable can be computed. In the case that
-    epsilon and delta are defined then the budget_proportions parameter
-    must be provided, specifying what fraction of the total budget each
-    mechanism is allocated. For budget_proportions = [p_1, p_2, ...]
-    the noise parameters are then computed as follows. We find large_epsilon
-    and noise parameters [sigma_1, sigma_2, ...] such that the following two
-    constraints hold:
-    1. For each i, mechanism_i with noise parameter sigma_i is (large_epsilon * p_i, delta)
-    DP after all composition steps,
-    2. The composition of all mechanisms over all steps is (epsilon, delta) DP.
+    Tracks the privacy loss over multiple mechanisms simultaneously.
 
-    :param num_compositions:
-        Maximum number of compositions to be performed with each mechanism.
-    :param sampling_probability:
-       Maximum probability of sampling each entity being privatized. E.g. if
-       the unit of privacy is one device, this is the probability of each
-       device participating.
+    This class can be used in a number of different ways.
+
+    1. An overall budget (total_epsilon, total_delta) is known, and we wish to
+    find the corresponding noise parameters of each of the mechanisms so that
+    the composition of all mechanisms adheres to the overall budget.
+    The budget_proportions parameter specifies what fraction of the total budget
+    each mechanism is allocated. For budget_proportions = [p_1, p_2, ...] the
+    noise parameters are then computed as follows. When the accountant class
+    is the same for each mechanism we find naive_epsilon > total_epsilon and
+    noise parameters [sigma_1, sigma_2, ...] such that the following two
+    constraints hold:
+        A. For each i, mechanism_i with noise parameter sigma_i is
+        (naive_epsilon * p_i, total_delta * p_i) DP after all composition steps,
+        B. The composition of all mechanisms over all steps is
+        (total_epsilon, total_delta) DP.
+    When the accountant classes to be used for each mechanism are different we
+    can only use basic composition and the noise parameter for each mechanism is computed
+    separately so that mechanism_i is (total_epsilon * p_i, total_delta * p_i) DP
+
+    2. The individual mechanism privacy budgets are known, i.e. mechanism_epsilons and
+    mechanism_deltas are given. In this case we can compute the required noise parameter
+    of each mechanism. The overall budget is then computed as described in 3.
+
+    3. The mechanism noise parameters are known, either because they have been computed
+    in 2. or because they have been given directly. In this case we compute the overall
+    privacy budget (total_epsilon, total_delta) by efficient composition if possible
+    (i.e. when using the same privacy accountant class) and by basic composition if not
+    possible.
+
     :param mechanisms:
         The list of noise mechanisms to be used, each can be either Gaussian or Laplace.
-    :param epsilon:
-        The privacy loss random variable. The total epsilon allowed for
-        the composition of all the mechanisms.
-    :param delta:
-        The probability that all privacy will be lost. The total delta allowed for
-        the composition of all the mechanisms.
+    :param accountants:
+        An accountant class, or list of accountant classes, specifying the type of
+        accountant being used for each of the mechanisms. Must be one of
+        PLDPrivacyAccountant, PRVPrivacyAccountant or RDPPrivacyAccountant.
+    :param num_compositions:
+        A positive integer, or list of positive integers, specifying the maximum
+        number of compositions to be performed with each mechanism.
+    :param sampling_probability:
+        A probability, or list of probabilities, specifying the sampling rate
+        of each mechanism.
+    :param total_epsilon:
+        The total epsilon allowed for the composition of all the mechanisms.
+    :param total_delta:
+        The total delta allowed for the composition of all the mechanisms.
+    :param mechanism_epsilons:
+        The list of individual epsilons allowed for each mechanism.
+    :param mechanism_deltas:
+        The list of individual deltas allowed for each mechanism.
     :param budget_proportions:
-        List specifying the proportion of the total (epsilon, delta) privacy budget
-        each mechanism is allocated.
+        List specifying the proportion of the overall (total_epsilon, total_delta) privacy budget
+        each mechanism is allocated. Defaults to [1 / len(mechanisms)] * len(mechanisms) if not set,
+        i.e. even split of the overall budget.
     :param noise_parameters:
         The parameters for DP noise for each mechanism. For the Gaussian
         mechanism, the noise parameter is the standard deviation of the noise.
@@ -70,66 +91,308 @@ class JointPrivacyAccountant:
         to be added for privatization. Typically used to experiment with lower
         sampling probabilities when it is not possible or desirable to increase
         the population size of the units being privatized, e.g. user devices.
+    :param pld_accountant_kwargs:
+        Optional key word arguments that are fed into the PLDPrivacyAccountant
+        constructor to change the default parameters, see privacy_accountant.py
+    :param prv_accountant_kwargs:
+        Optional key word arguments that are fed into the PRVPrivacyAccountant
+        constructor to change the default parameters, see privacy_accountant.py
     """
-    num_compositions: int
-    sampling_probability: float
     mechanisms: List[str]
-    epsilon: Optional[float] = None
-    delta: Optional[float] = None
+    accountants: Type[PFL_ACCOUNTANT_TYPE] | List[Type[PFL_ACCOUNTANT_TYPE]]
+    num_compositions: int | List[int]
+    sampling_probability: float | List[float]
+    total_epsilon: Optional[float] = None
+    total_delta: Optional[float] = None
+    mechanism_epsilons: Optional[List[float]] = None
+    mechanism_deltas: Optional[List[float]] = None
     budget_proportions: Optional[List[float]] = None
     noise_parameters: Optional[List[float]] = None
     noise_scale: float = 1.0
+    pld_accountant_kwargs: Optional[Dict] = None
+    prv_accountant_kwargs: Optional[Dict] = None
 
     def __post_init__(self):
-        assert [
-            self.epsilon, self.delta, self.noise_parameters
-        ].count(None) <= 1, (
-            f'At least two of epsilon ({self.epsilon}),'
-            f'delta ({self.delta}) and noise parameters ({self.noise_parameters})'
-            'must be defined for a joint privacy accountant')
-        if self.noise_scale <= 0 or self.noise_scale > 1.0:
-            raise ValueError("noise_scale must be in range (0,1]")
-        assert (
-            self.sampling_probability >= 0
-            and self.sampling_probability <= 1.0), (
-                f'Sampling probability {self.sampling_probability} is invalid.'
-                'Must be in range [0, 1]')
-        assert self.num_compositions > 0 and isinstance(
-            self.num_compositions,
-            int), ('Number of compositions must be a positive integer')
-        if self.noise_parameters is not None:
-            for noise_parameter in self.noise_parameters:
-                assert noise_parameter > 0, (
-                    'All noise parameters must be positive real values')
-        if self.epsilon is not None:
-            assert self.epsilon >= 0, (
-                'Epsilon must be a non-negative real value')
-        if self.delta is not None:
-            assert self.delta > 0 and self.delta < 1, (
-                'Delta should be a positive real value in range (0, 1)')
+        self.check_valid_parameter_settings()
 
-        self.mechanisms = [mechanism.lower() for mechanism in self.mechanisms]
-
-        for mechanism in self.mechanisms:
-            assert mechanism in [
-                'gaussian', 'laplace'
-            ], ('Only gaussian and laplace mechanisms are supported')
-
-        if self.budget_proportions:
-            assert len(self.mechanisms) == len(self.budget_proportions), (
-                'Mechansim names and budget proportions must have the same length'
-            )
-
-            assert math.isclose(
-                sum(self.budget_proportions), 1,
-                rel_tol=1e-3), ('Privacy budget proportions must sum to 1')
-
-            for p in self.budget_proportions:
-                assert (p > 0) and (p < 1), (
-                    'Privacy budget proportions must be in range (0, 1)')
-
+        # Set initial min and max bounds for the inner binary search
         self.min_bounds = [MIN_BOUND_NOISE_PARAMETER] * len(self.mechanisms)
         self.max_bounds = [MAX_BOUND_NOISE_PARAMETER] * len(self.mechanisms)
+
+        if self.mechanism_epsilons is not None:
+            # Individual mechanism privacy budgets are given and noise parameters
+            # can be computed separately
+            self.noise_parameters = self.compute_for_each_mechanism(
+                mechanism_epsilons=self.mechanism_epsilons,
+                mechanism_deltas=self.mechanism_deltas)
+
+        if len(set(self.accountants)) == 1:
+            # All accountant classes are the same, hence we can efficiently compose
+            accountant_cls = self.accountants[0]
+            accountant_method = self.get_accountant_method(accountant_cls)
+            accountant_kwargs = self.get_accountant_kwargs(accountant_cls)
+
+            # Total epsilon, total delta, and noise parameters all defined. Check if
+            # composition of mechanisms with given noise parameters satisfies
+            # (total_epsilon, total_delta)-DP.
+            if [self.total_epsilon, self.total_delta, self.noise_parameters].count(None) == 0:
+                assert math.isclose(
+                    accountant_method(
+                         self.mechanisms, self.noise_parameters,
+                         self.num_compositions, self.sampling_probability,
+                         epsilon=self.total_epsilon, **accountant_kwargs),
+                    self.total_delta,
+                    rel_tol=1e-3), (
+                    'Invalid settings of epsilon, delta, noise_parameters')
+            else:
+                if self.noise_parameters is not None:
+                    if self.total_epsilon:
+                        self.total_delta = accountant_method(
+                            self.mechanisms, self.noise_parameters,
+                            self.num_compositions, self.sampling_probability,
+                            epsilon=self.total_epsilon, **accountant_kwargs)
+                    else:
+                        self.total_epsilon = accountant_method(
+                            self.mechanisms, self.noise_parameters,
+                            self.num_compositions, self.sampling_probability,
+                            delta=self.total_delta, **accountant_kwargs)
+
+                else:
+                    # Do binary search over naive_epsilon. Within each iteration of the binary search
+                    # we run an inner binary search to compute the noise parameter for each mechanism
+                    # that enforce condition 1 from above.
+                    def compute_delta(naive_epsilon, delta_method=accountant_method):
+                        self.noise_parameters = self.compute_for_each_mechanism(
+                            mechanism_epsilons=[naive_epsilon * p for p in self.budget_proportions],
+                            mechanism_deltas=[self.total_delta * p for p in self.budget_proportions],
+                        )
+
+                        delta = delta_method(
+                            self.mechanisms,
+                            self.noise_parameters,
+                            self.num_compositions,
+                            self.sampling_probability,
+                            epsilon=self.total_epsilon,
+                        )
+
+                        if delta < self.total_delta:
+                            # large_epsilon was too small, i.e. noise was too large.
+                            # We can decrease our starting max bound for the next noise parameter search
+                            self.max_bounds = self.noise_parameters
+                        else:
+                            # large_epsilon was too large, i.e. noise was too small.
+                            # We can increase our starting min bound for the next noise parameter search
+                            self.min_bounds = self.noise_parameters
+
+                        return delta
+
+                    try:
+                        self.naive_epsilon = binary_search_function(
+                            func=compute_delta,
+                            func_monotonically_increasing=True,
+                            target_value=self.total_delta,
+                            min_bound=max(MIN_BOUND_EPSILON, self.total_epsilon),
+                            max_bound=min(MAX_BOUND_EPSILON, self.total_epsilon / min(*self.budget_proportions)),
+                            rtol=RTOL_EPSILON,
+                            confidence_threshold=
+                            CONFIDENCE_THRESHOLD_EPSILON)
+                    except Exception as e:
+                        raise ValueError(
+                            'Error occurred during binary search for '
+                            'large_epsilon: '
+                            f'{e}') from e
+
+        else:
+            # Accountant classes are different, we must use basic composition
+            if self.mechanism_epsilons is not None:
+                self.total_epsilon = sum(self.mechanism_epsilons)
+                self.total_delta = sum(self.mechanism_deltas)
+            else:
+                if [self.total_epsilon, self.total_delta, self.noise_parameters].count(None) == 0:
+                    # Check vals are correct
+                    pass
+
+                else:
+                    if self.noise_parameters is not None:
+                        if self.total_epsilon:
+                            mechanism_epsilons = [self.total_epsilon * p for p in self.budget_proportions]
+                            deltas = self.compute_for_each_mechanism(
+                                mechanism_epsilons=mechanism_epsilons,
+                                noise_parameters=self.noise_parameters
+                            )
+                            self.total_delta = sum(deltas)
+
+                        else:
+                            assert self.total_delta is not None
+                            mechanism_deltas = [self.total_delta * p for p in self.budget_proportions]
+                            epsilons = self.compute_for_each_mechanism(
+                                mechanism_deltas=mechanism_deltas,
+                                noise_parameters=self.noise_parameters
+                            )
+                            self.total_epsilon = sum(epsilons)
+
+                    else:
+                        mechanism_epsilons = [b * self.total_epsilon for b in self.budget_proportions]
+                        mechanism_deltas = [b * self.total_delta for b in self.budget_proportions]
+
+                        self.noise_parameters = self.compute_for_each_mechanism(
+                            mechanism_epsilons=mechanism_epsilons,
+                            mechanism_deltas=mechanism_deltas
+                        )
+
+    def compute_for_each_mechanism(self, mechanism_epsilons=None, mechanism_deltas=None, noise_parameters=None):
+        """
+        Compute for each mechanism independently using the corresponding accountant.
+        """
+
+        if noise_parameters is None:
+            computed_val = 'noise_parameter'
+            noise_parameters = [None] * len(mechanism_epsilons)
+        elif mechanism_deltas is None:
+            computed_val = 'delta'
+            mechanism_deltas = [None] * len(mechanism_epsilons)
+        else:
+            computed_val = 'epsilon'
+            mechanism_epsilons = [None] * len(mechanism_deltas)
+
+        computed_vals = []
+        for mechanism, accountant_cls, n, p, e, d, s, min_bound, max_bound in zip(self.mechanisms,
+                                                                                  self.accountants,
+                                                                                  self.num_compositions,
+                                                                                  self.sampling_probability,
+                                                                                  mechanism_epsilons,
+                                                                                  mechanism_deltas,
+                                                                                  noise_parameters,
+                                                                                  self.min_bounds,
+                                                                                  self.max_bounds):
+
+            accountant = accountant_cls(mechanism=mechanism,
+                                        epsilon=e,
+                                        delta=d,
+                                        noise_parameter=s,
+                                        num_compositions=n,
+                                        sampling_probability=p,
+                                        min_bound_noise_parameter=min_bound,
+                                        max_bound_noise_parameter=max_bound,
+                                        **self.get_accountant_kwargs(accountant_cls))
+            computed_vals.append(getattr(accountant, computed_val))
+
+        return computed_vals
+
+    def get_accountant_kwargs(self, accountant_cls):
+        get_kwargs_accountant_map = {
+            PLDPrivacyAccountant: self.pld_accountant_kwargs,
+            PRVPrivacyAccountant: self.prv_accountant_kwargs,
+            RDPPrivacyAccountant: {},
+        }
+        return get_kwargs_accountant_map[accountant_cls]
+
+    def get_accountant_method(self, accountant_cls):
+        get_method_accountant_map = {
+            PLDPrivacyAccountant: self.composed_pld_accountant,
+            PRVPrivacyAccountant: self.composed_prv_accountant,
+            RDPPrivacyAccountant: self.composed_rdp_accountant,
+        }
+        return get_method_accountant_map[accountant_cls]
+
+    @staticmethod
+    def composed_pld_accountant(mechanisms, noise_parameters, num_compositions, sampling_probability,
+                                epsilon=None,
+                                delta=None,
+                                **kwargs
+                                ):
+        assert [epsilon, delta].count(None) <= 1, (
+            'At least one of epsilon and delta must be specified')
+
+        composed_pld = None
+        for mechanism, noise_parameter, n, p in zip(mechanisms, noise_parameters, num_compositions, sampling_probability):
+            if mechanism == 'gaussian':
+                pld = privacy_loss_distribution.from_gaussian_mechanism(
+                    standard_deviation=noise_parameter,
+                    sensitivity=1,
+                    sampling_prob=p,
+                    **kwargs)
+            elif mechanism == 'laplace':
+                pld = privacy_loss_distribution.from_laplace_mechanism(
+                    parameter=noise_parameter,
+                    sensitivity=1,
+                    sampling_prob=p,
+                    **kwargs)
+
+            else:
+                raise ValueError(f'mechanism {mechanism} is not supported.')
+
+            if composed_pld is None:
+                composed_pld = pld.self_compose(n)
+            else:
+                composed_pld = composed_pld.compose(pld.self_compose(n))
+
+        if delta is None:
+            return composed_pld.get_delta_for_epsilon(epsilon)
+        else:
+            return composed_pld.get_epsilon_for_delta(delta)
+
+    @staticmethod
+    def composed_prv_accountant(mechanisms, noise_parameters, num_compositions, sampling_probability,
+                                epsilon=None, delta=None,
+                                **kwargs):
+
+        assert [epsilon, delta].count(None) <= 1, (
+            'At least one of epsilon and delta must be specified')
+
+        prvs = []
+        for mechanism, noise_parameter, _, p in zip(mechanisms, noise_parameters, num_compositions, sampling_probability):
+            if mechanism == 'gaussian':
+                prv = PoissonSubsampledGaussianMechanism(
+                    sampling_probability=p,
+                    noise_multiplier=noise_parameter)
+
+            elif mechanism == 'laplace':
+                prv = LaplaceMechanism(mu=noise_parameter)
+
+            else:
+                raise ValueError(
+                    f'Mechanism {mechanism} is not supported for PRV accountant')
+
+            prvs.append(prv)
+
+        acc_prv = PRVAccountant(prvs=prvs,
+                                max_self_compositions=num_compositions,
+                                **kwargs)
+
+        if delta is None:
+            return acc_prv.compute_delta(epsilon, num_compositions)[1]
+        else:
+            return acc_prv.compute_epsilon(delta, num_compositions)[1]
+
+    @staticmethod
+    def composed_rdp_accountant(mechanisms, noise_parameters, num_compositions, sampling_probability,
+                                epsilon=None, delta=None):
+
+        assert [epsilon, delta].count(None) <= 1, (
+            'At least one of epsilon and delta must be specified')
+
+        rdp_accountant = rdp_privacy_accountant.RdpAccountant()
+        for mechanism, noise_parameter, n, p in zip(mechanisms, noise_parameters, num_compositions, sampling_probability):
+            if mechanism == 'gaussian':
+                event = dp_event.PoissonSampledDpEvent(
+                    p,
+                    dp_event.GaussianDpEvent(noise_parameter))
+
+            elif mechanism == 'laplace':
+                event = dp_event.LaplaceDpEvent(noise_parameter)
+
+            else:
+                raise ValueError(
+                    f'Mechanism {mechanism} is not supported for Renyi accountant')
+
+            rdp_accountant = rdp_accountant.compose(
+                event, n)
+
+        if delta is None:
+            return rdp_accountant.get_delta(epsilon)
+        else:
+            return rdp_accountant.get_epsilon(delta)
 
     @property
     def cohort_noise_parameters(self):
@@ -142,498 +405,575 @@ class JointPrivacyAccountant:
             for noise_parameter in self.noise_parameters
         ]
 
-
-@dataclass
-class JointPLDPrivacyAccountant(JointPrivacyAccountant):
-    """
-    Uses Privacy Loss Distribution (PLD) privacy accountant, from dp-accounting
-    package for each mechanism.
-
-    :param value_discretization_interval:
-        The length of the dicretization interval for the privacy loss
-        distribution. Rounding will occur to integer multiples of
-        value_discretization_interval. Smaller values yield more accurate
-        estimates of the privacy loss, while incurring higher compute and
-        memory. Hence, larger values decrease computation time. Note that the
-        accountant algorithm maintains similar error bounds as the value of
-        value_discretization_interval is changed.
-    :param use_connect_dots:
-        boolean indicating whether or not to use Connect-the-Dots algorithm by
-        Doroshenko et al., which gives tighter discrete approximations of PLDs.
-    :param pessimistic_estimate:
-        boolean indicating whether rounding used in PLD algorithm results in
-        epsilon-hockey stick divergence computation yielding upper estimate to
-        real value.
-    :param log_mass_truncation_bound:
-        The natural log of probability mass that may be discarded from noise
-        distribution.
-        Larger values will increase the error.
-    """
-    value_discretization_interval: float = 1e-4
-    use_connect_dots: bool = True
-    pessimistic_estimate: bool = True
-    log_mass_truncation_bound: float = -50
-
-    def __post_init__(self):
-        super().__post_init__()
-
-        # Epsilon, delta, noise parameter all defined. Nothing to do.
-        if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
-            assert math.isclose(
-                self.get_composed_accountant(
-                    self.mechanisms, self.noise_parameters,
-                    self.pessimistic_estimate, self.sampling_probability,
-                    self.use_connect_dots, self.value_discretization_interval,
-                    self.num_compositions).get_delta_for_epsilon(self.epsilon),
-                self.delta,
-                rel_tol=1e-3), (
-                    'Invalid settings of epsilon, delta, noise_parameters for '
-                    'JointPLDPrivacyAccountant')
-
-        else:
-            # Only two of epsilon, delta, noise parameters defined.
-            # Compute remaining variable
-            if self.noise_parameters:
-                composed_pld = self.get_composed_accountant(
-                    self.mechanisms, self.noise_parameters,
-                    self.pessimistic_estimate, self.sampling_probability,
-                    self.use_connect_dots, self.value_discretization_interval,
-                    self.num_compositions)
-
-                if self.epsilon:
-                    self.delta = composed_pld.get_delta_for_epsilon(
-                        self.epsilon)
-                else:
-                    self.epsilon = composed_pld.get_epsilon_for_delta(
-                        self.delta)
-
-            else:
-                # Do binary search over large_epsilon. Within each iteration of the binary search
-                # we run an inner binary search to compute the noise parameter for each mechanism
-                # that enforce condition 1 above.
-                def compute_delta(large_epsilon):
-                    delta = self.get_composed_accountant(
-                        self.mechanisms,
-                        self.compute_noise_paramters(large_epsilon),
-                        self.pessimistic_estimate,
-                        self.sampling_probability,
-                        self.use_connect_dots,
-                        self.value_discretization_interval,
-                        self.num_compositions,
-                    ).get_delta_for_epsilon(self.epsilon)
-
-                    if delta < self.delta:
-                        # large_epsilon was too small, i.e. noise was too large.
-                        # We can decrease our starting max bound for the next noise parameter search
-                        self.max_bounds = self.noise_parameters
-                    else:
-                        # large_epsilon was too large, i.e. noise was too small.
-                        # We can increase our starting min bound for the next noise parameter search
-                        self.min_bounds = self.noise_parameters
-
-                    return delta
-
-                try:
-                    self.large_epsilon = binary_search_function(
-                        func=compute_delta,
-                        func_monotonically_increasing=True,
-                        target_value=self.delta,
-                        min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
-                        max_bound=min(
-                            MAX_BOUND_EPSILON,
-                            self.epsilon / min(*self.budget_proportions)),
-                        rtol=RTOL_EPSILON,
-                        confidence_threshold=CONFIDENCE_THRESHOLD_EPSILON)
-                except Exception as e:
-                    raise ValueError(
-                        'Error occurred during binary search for '
-                        'large_epsilon using PLD privacy accountant: '
-                        f'{e}') from e
-
-    @staticmethod
-    def get_composed_accountant(mechanisms, noise_parameters,
-                                pessimistic_estimate, sampling_probability,
-                                use_connect_dots,
-                                value_discretization_interval,
-                                num_compositions):
-        composed_pld = None
-        for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
-            if mechanism == 'gaussian':
-                pld = privacy_loss_distribution.from_gaussian_mechanism(
-                    standard_deviation=noise_parameter,
-                    sensitivity=1,
-                    pessimistic_estimate=pessimistic_estimate,
-                    sampling_prob=sampling_probability,
-                    use_connect_dots=use_connect_dots,
-                    value_discretization_interval=value_discretization_interval
-                )
-            elif mechanism == 'laplace':
-                pld = privacy_loss_distribution.from_laplace_mechanism(
-                    parameter=noise_parameter,
-                    sensitivity=1,
-                    pessimistic_estimate=pessimistic_estimate,
-                    sampling_prob=sampling_probability,
-                    use_connect_dots=use_connect_dots,
-                    value_discretization_interval=value_discretization_interval
-                )
-
-            else:
-                raise ValueError(f'mechanism {mechanism} is not supported.')
-
-            if composed_pld is None:
-                composed_pld = pld.self_compose(num_compositions)
-            else:
-                composed_pld = composed_pld.compose(
-                    pld.self_compose(num_compositions))
-
-        return composed_pld
-
-    def compute_noise_paramters(self, large_epsilon):
+    def check_valid_parameter_settings(self):
         """
-        Compute noise parameter for each mechanism such that when self composed
-        it is (large_epsilon * p, delta) DP, where p is the budget proportion
-        of the mechanism
+        Check that all input parameter settings are valid
         """
-        noise_parameters = []
 
-        for mechanism, p, min_bound, max_bound in zip(self.mechanisms,
-                                                      self.budget_proportions,
-                                                      self.min_bounds,
-                                                      self.max_bounds):
-            mechanism_epsilon = large_epsilon * p
-            func = lambda noise_param, mech=mechanism, mech_epsilon=mechanism_epsilon: self.get_composed_accountant(
-                [mech],
-                [noise_param],
-                self.pessimistic_estimate,
-                self.sampling_probability,
-                self.use_connect_dots,
-                self.value_discretization_interval,
-                self.num_compositions,
-            ).get_delta_for_epsilon(mech_epsilon)
-            try:
-                noise_parameter = binary_search_function(
-                    func=func,
-                    func_monotonically_increasing=False,
-                    target_value=self.delta,
-                    min_bound=min_bound,
-                    max_bound=max_bound,
-                    rtol=RTOL_NOISE_PARAMETER,
-                    confidence_threshold=CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
-            except Exception as e:
-                raise ValueError(
-                    'Error occurred during binary search for '
-                    'noise_parameter using PLD privacy accountant: '
-                    f'{e}') from e
+        # Check mechanisms
+        self.mechanisms = [mechanism.lower() for mechanism in self.mechanisms]
+        for mechanism in self.mechanisms:
+            assert mechanism in ['gaussian', 'laplace'], (
+                'Only gaussian and laplace mechanisms are supported.')
 
-            noise_parameters.append(noise_parameter)
-
-        self.noise_parameters = noise_parameters
-        return noise_parameters
-
-
-@dataclass
-class JointPRVPrivacyAccountant(JointPrivacyAccountant):
-    """
-    For each mechanism uses the Privacy Random Variable (PRV) accountant,
-    for heterogeneous composition, using prv-accountant package.
-    prv-accountant package: https://pypi.org/project/prv-accountant/
-    Based on: “Numerical Composition of Differential Privacy”, Gopi et al.,
-    2021, https://arxiv.org/pdf/2106.02848.pdf
-    The PRV accountant methods compute_delta() and compute_epsilon() return
-    a lower bound, an estimated value, and an upper bound for the delta and
-    epsilon respectively. The estimated value is used for all further
-    computations.
-
-    :param eps_error:
-        Maximum permitted error in epsilon. Typically around 0.1.
-    :param delta_error:
-        Maximum error allowed in delta. Typically around delta * 1e-3
-    """
-    eps_error: Optional[float] = 0.07
-    delta_error: Optional[float] = 1e-10
-
-    def __post_init__(self):
-        super().__post_init__()
-
-        # epsilon, delta, noise_parameter all defined
-        if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
-            assert math.isclose(
-                self.get_composed_accountant(
-                    self.mechanisms, self.noise_parameters,
-                    self.sampling_probability, self.num_compositions,
-                    self.eps_error, self.delta_error).compute_delta(
-                        self.epsilon,
-                        [self.num_compositions] * len(self.mechanisms))[1],
-                self.delta,
-                rel_tol=1e-3), (
-                    'Invalid settings of epsilon, delta, noise_parameter'
-                    'for PRVPrivacyAccountant')
-
+        # Check accountants
+        if isinstance(self.accountants, list):
+            assert len(self.accountants) == len(self.mechanisms), (
+                'Accountants and mechanism names must have the same length'
+            )
         else:
-            if self.noise_parameters:
-                prv_acc = self.get_composed_accountant(
-                    self.mechanisms, self.noise_parameters,
-                    self.sampling_probability, self.num_compositions,
-                    self.eps_error, self.delta_error)
+            self.accountants = [self.accountants] * len(self.mechanisms)
 
-                if self.epsilon:
-                    # prv_acc.compute_delta() returns lower bound on delta,
-                    # estimate of delta, and upper bound on delta.
-                    # Estimate of delta is used.
-                    (_, delta_estim, _) = prv_acc.compute_delta(
-                        self.epsilon,
-                        [self.num_compositions] * len(self.mechanisms))
-                    self.delta = delta_estim
-                else:
-                    # prv_acc.compute_epsilon() returns lower bound on epsilon,
-                    # estimate of epsilon, and upper bound on epsion.
-                    # Estimate of epsilon is used.
-                    (_, epsilon_estim, _) = prv_acc.compute_epsilon(
-                        self.delta,
-                        [self.num_compositions] * len(self.mechanisms))
-                    self.epsilon = epsilon_estim
+        assert all(isinstance(acc, PFL_ACCOUNTANT_TYPE) for acc in self.accountants), (
+            f'Accountants must be one of the accountant classes {PFL_ACCOUNTANT_TYPE}'
+        )
 
-            else:
-                # Do binary search over large_epsilon. Within each iteration of the binary search
-                # we run an inner binary search to compute the noise parameter for each mechanism
-                # that enforce condition 1 from above.
-                def compute_delta(large_epsilon):
-                    delta = self.get_composed_accountant(
-                        self.mechanisms,
-                        self.compute_noise_paramters(large_epsilon),
-                        self.sampling_probability,
-                        self.num_compositions,
-                        self.eps_error,
-                        self.delta_error,
-                    ).compute_delta(self.epsilon, [self.num_compositions] *
-                                    len(self.mechanisms))[1]
-
-                    if delta < self.delta:
-                        # large_epsilon was too small, i.e. noise was too large.
-                        # We can decrease our starting max bound for the next noise parameter search
-                        self.max_bounds = self.noise_parameters
-                    else:
-                        # large_epsilon was too large, i.e. noise was too small.
-                        # We can increase our starting min bound for the next noise parameter search
-                        self.min_bounds = self.noise_parameters
-
-                    return delta
-
-                try:
-                    self.large_epsilon = binary_search_function(
-                        func=compute_delta,
-                        func_monotonically_increasing=True,
-                        target_value=self.delta,
-                        min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
-                        max_bound=min(
-                            MAX_BOUND_EPSILON,
-                            self.epsilon / min(*self.budget_proportions)),
-                        rtol=RTOL_EPSILON,
-                        confidence_threshold=CONFIDENCE_THRESHOLD_EPSILON)
-                except Exception as e:
-                    raise ValueError(
-                        'Error occurred during binary search for '
-                        'large_epsilon using PRV privacy accountant: '
-                        f'{e}') from e
-
-    @staticmethod
-    def get_composed_accountant(mechanisms, noise_parameters,
-                                sampling_probability, num_compositions,
-                                eps_error, delta_error):
-
-        prvs = []
-        for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
-            if mechanism == 'gaussian':
-                prv = PoissonSubsampledGaussianMechanism(
-                    sampling_probability=sampling_probability,
-                    noise_multiplier=noise_parameter)
-
-            elif mechanism == 'laplace':
-                prv = LaplaceMechanism(mu=noise_parameter)
-
-            else:
-                raise ValueError(
-                    f'Mechanism {mechanism} is not supported for PRV accountant'
-                )
-
-            prvs.append(prv)
-
-        acc_prv = PRVAccountant(prvs=prvs,
-                                max_self_compositions=[int(num_compositions)] *
-                                len(prvs),
-                                eps_error=eps_error,
-                                delta_error=delta_error)
-
-        return acc_prv
-
-    def compute_noise_paramters(self, large_epsilon):
-        noise_parameters = []
-
-        for mechanism, p, min_bound, max_bound in zip(self.mechanisms,
-                                                      self.budget_proportions,
-                                                      self.min_bounds,
-                                                      self.max_bounds):
-            mechanism_epsilon = large_epsilon * p
-            func = lambda noise_param, mech=mechanism, mech_epsilon=mechanism_epsilon: self.get_composed_accountant(
-                [mech],
-                [noise_param],
-                self.sampling_probability,
-                self.num_compositions,
-                self.eps_error,
-                self.delta_error,
-            ).compute_delta(mech_epsilon, [self.num_compositions])[1]
-            try:
-                noise_parameter = binary_search_function(
-                    func=func,
-                    func_monotonically_increasing=False,
-                    target_value=self.delta,
-                    min_bound=min_bound,
-                    max_bound=max_bound,
-                    rtol=RTOL_NOISE_PARAMETER,
-                    confidence_threshold=CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
-            except Exception as e:
-                raise ValueError(
-                    'Error occurred during binary search for '
-                    'noise_parameter using PRV privacy accountant: '
-                    f'{e}') from e
-
-            noise_parameters.append(noise_parameter)
-
-        self.noise_parameters = noise_parameters
-        return noise_parameters
-
-
-@dataclass
-class JointRDPPrivacyAccountant(JointPrivacyAccountant):
-    """
-    For each mechanism uses the Privacy accountant using Renyi differential
-    privacy (RDP) from dp-accounting package.
-    Implementation in dp-accounting: https://github.com/google/differential-privacy/blob/main/python/dp_accounting/rdp/rdp_privacy_accountant.py # pylint: disable=line-too-long
-    The default neighbouring relation for the RDP account is "add or remove
-    one". The default RDP orders used are:
-    ([1 + x / 10. for x in range(1, 100)] + list(range(11, 64)) +
-    [128, 256, 512, 1024]).
-    """
-
-    def __post_init__(self):
-        super().__post_init__()
-
-        # epsilon, delta, noise_parameters all defined
-        if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
-            assert math.isclose(
-                self.get_composed_accountant(
-                    self.mechanisms, self.noise_parameters,
-                    self.sampling_probability,
-                    self.num_compositions).get_delta(self.epsilon),
-                self.delta,
-                rel_tol=1e-3), (
-                    'Invalid settings of epsilon, delta, noise_parameter '
-                    'for RDPPrivacyAccountant')
-
+        # Check num_compositions
+        if isinstance(self.num_compositions, list):
+            assert len(self.num_compositions) == len(self.mechanisms), (
+                'Num compostitions and mechanism names must have the same length'
+            )
         else:
-            if self.noise_parameters:
+            self.num_compositions = [self.num_compositions] * len(self.mechanisms)
 
-                rdp_accountant = self.get_composed_accountant(
-                    self.mechanisms, self.noise_parameters,
-                    self.sampling_probability, self.num_compositions)
+        assert all(0 < n and isinstance(n, int) for n in self.num_compositions), (
+                'Number of compositions must be a positive integer')
 
-                if self.epsilon:
-                    self.delta = rdp_accountant.get_delta(self.epsilon)
+        # Check sampling_probability
+        if isinstance(self.sampling_probability, list):
+            assert len(self.sampling_probability) == len(self.mechanisms), (
+                'Sampling probabilites and mechanism names must have the same length'
+            )
+        else:
+            self.sampling_probability = [self.sampling_probability] * len(self.mechanisms)
 
-                else:
-                    self.epsilon = rdp_accountant.get_epsilon(self.delta)
+        assert all(0 <= p <= 1.0 for p in self.sampling_probability), (
+            f'Sampling probabilities {self.sampling_probability} are invalid.'
+            'Must be in range [0, 1]')
 
-            else:
-                # Do binary search over large_epsilon. Within each iteration of the binary search
-                # we run an inner binary search to compute the noise parameter for each mechanism
-                # that enforce condition 1 from above.
-                def compute_delta(large_epsilon):
-                    delta = self.get_composed_accountant(
-                        self.mechanisms,
-                        self.compute_noise_paramters(large_epsilon),
-                        self.sampling_probability,
-                        self.num_compositions).get_delta(self.epsilon)
+        # Check total_epsilon
+        if self.total_epsilon is not None:
+            assert self.total_epsilon >= 0, (
+                'Epsilon must be a non-negative real value')
 
-                    if delta < self.delta:
-                        # large_epsilon was too small, i.e. noise was too large.
-                        # We can decrease our starting max bound for the next noise parameter search
-                        self.max_bounds = self.noise_parameters
-                    else:
-                        # large_epsilon was too large, i.e. noise was too small.
-                        # We can increase our starting min bound for the next noise parameter search
-                        self.min_bounds = self.noise_parameters
+        # Check total_delta
+        if self.total_delta is not None:
+            assert 0 < self.total_delta < 1, (
+                'Delta should be a positive real value in range (0, 1)')
 
-                    return delta
+        # Check mechanism_epsilons and mechanism_deltas
+        if (self.mechanism_epsilons is not None) or (self.mechanism_deltas is not None):
+            assert (self.mechanism_epsilons is not None) and (self.mechanism_deltas is not None), (
+                'If one of mechanism_epsilons and mechanism_deltas is set then both must be.'
+            )
 
-                try:
-                    self.large_epsilon = binary_search_function(
-                        func=compute_delta,
-                        func_monotonically_increasing=True,
-                        target_value=self.delta,
-                        min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
-                        max_bound=min(
-                            MAX_BOUND_EPSILON,
-                            self.epsilon / min(*self.budget_proportions)),
-                        rtol=RTOL_EPSILON,
-                        confidence_threshold=CONFIDENCE_THRESHOLD_EPSILON)
-                except Exception as e:
-                    raise ValueError(
-                        'Error occurred during binary search for '
-                        'large_epsilon using RDP privacy accountant: '
-                        f'{e}') from e
+            assert all(eps >= 0 for eps in self.mechanism_epsilons), (
+                'All mechanism epsilons must be non-negative real values'
+            )
 
-    @staticmethod
-    def get_composed_accountant(mechanisms, noise_parameters,
-                                sampling_probability, num_compositions):
+            assert all(0 < delta < 1 for delta in self.mechanism_deltas), (
+                'All mechanism deltas must be positive real values in (0, 1)'
+            )
 
-        rdp_accountant = rdp_privacy_accountant.RdpAccountant()
-        for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
-            if mechanism == 'gaussian':
-                event = dp_event.PoissonSampledDpEvent(
-                    sampling_probability,
-                    dp_event.GaussianDpEvent(noise_parameter))
+            assert len(self.mechanism_epsilons) == len(self.mechanisms), (
+                'Mechanism epsilons and mechanism names must have the same length'
+            )
 
-            elif mechanism == 'laplace':
-                event = dp_event.LaplaceDpEvent(noise_parameter)
-                pass
+            assert len(self.mechanism_deltas) == len(self.mechanisms), (
+                'Mechanism deltas and mechanism names must have the same length'
+            )
 
-            else:
-                raise ValueError(
-                    f'Mechanism {mechanism} is not supported for Renyi accountant'
-                )
+        # Check budget_proportions
+        if self.budget_proportions is not None:
+            assert len(self.mechanisms) == len(self.budget_proportions), (
+                'Mechansim names and budget proportions must have the same length'
+            )
 
-            rdp_accountant = rdp_accountant.compose(event,
-                                                    int(num_compositions))
+            assert all(0 < p < 1.0 for p in self.budget_proportions), (
+                    f'Budget proportions {self.budget_proportions} are invalid.'
+                    'Must be in range (0, 1)')
 
-        return rdp_accountant
+            assert math.isclose(sum(self.budget_proportions), 1, rel_tol=1e-3), (
+                'Privacy budget proportions must sum to 1.'
+            )
+        else:
+            self.budget_proportions = [1 / len(self.mechanisms)] * len(self.mechanisms)
 
-    def compute_noise_paramters(self, large_epsilon):
-        noise_parameters = []
+        # Check noise_parameters
+        if self.noise_parameters is not None:
+            assert all(0 < s for s in self.noise_parameters), (
+                    'All noise parameters must be positive real values.')
 
-        for mechanism, p, min_bound, max_bound in zip(self.mechanisms,
-                                                      self.budget_proportions,
-                                                      self.min_bounds,
-                                                      self.max_bounds):
-            mechanism_epsilon = large_epsilon * p
-            func = lambda noise_param, mech=mechanism, mech_epsilon=mechanism_epsilon: self.get_composed_accountant(
-                [mech], [noise_param], self.sampling_probability, self.
-                num_compositions).get_delta(mech_epsilon)
-            try:
-                noise_parameter = binary_search_function(
-                    func=func,
-                    func_monotonically_increasing=False,
-                    target_value=self.delta,
-                    min_bound=min_bound,
-                    max_bound=max_bound,
-                    rtol=RTOL_NOISE_PARAMETER,
-                    confidence_threshold=CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
-            except Exception as e:
-                raise ValueError(
-                    'Error occurred during binary search for '
-                    'noise_parameter using RDP privacy accountant: '
-                    f'{e}') from e
+        # Check noise_scale
+        if self.noise_scale <= 0 or self.noise_scale > 1.0:
+            raise ValueError("noise_scale must be in range (0,1]")
 
-            noise_parameters.append(noise_parameter)
+        assert [
+            self.total_epsilon, self.total_delta, self.noise_parameters
+        ].count(None) <= 1, (
+            f'At least two of total epsilon ({self.total_epsilon}),'
+            f'total delta ({self.total_delta}) and noise parameters ({self.noise_parameters})'
+            'must be defined for a joint privacy accountant')
 
-        self.noise_parameters = noise_parameters
-        return noise_parameters
+#
+#
+#
+# @dataclass
+# class JointPLDPrivacyAccountant(JointPrivacyAccountant):
+#     """
+#     Uses Privacy Loss Distribution (PLD) privacy accountant, from dp-accounting
+#     package for each mechanism.
+#
+#     :param value_discretization_interval:
+#         The length of the dicretization interval for the privacy loss
+#         distribution. Rounding will occur to integer multiples of
+#         value_discretization_interval. Smaller values yield more accurate
+#         estimates of the privacy loss, while incurring higher compute and
+#         memory. Hence, larger values decrease computation time. Note that the
+#         accountant algorithm maintains similar error bounds as the value of
+#         value_discretization_interval is changed.
+#     :param use_connect_dots:
+#         boolean indicating whether or not to use Connect-the-Dots algorithm by
+#         Doroshenko et al., which gives tighter discrete approximations of PLDs.
+#     :param pessimistic_estimate:
+#         boolean indicating whether rounding used in PLD algorithm results in
+#         epsilon-hockey stick divergence computation yielding upper estimate to
+#         real value.
+#     :param log_mass_truncation_bound:
+#         The natural log of probability mass that may be discarded from noise
+#         distribution.
+#         Larger values will increase the error.
+#     """
+#     value_discretization_interval: float = 1e-4
+#     use_connect_dots: bool = True
+#     pessimistic_estimate: bool = True
+#     log_mass_truncation_bound: float = -50
+#
+#     def __post_init__(self):
+#         super().__post_init__()
+#
+#         # Epsilon, delta, noise parameter all defined. Nothing to do.
+#         if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
+#             assert math.isclose(
+#                 self.get_composed_accountant(
+#                     self.mechanisms, self.noise_parameters,
+#                     self.pessimistic_estimate, self.sampling_probability,
+#                     self.use_connect_dots, self.value_discretization_interval,
+#                     self.num_compositions).get_delta_for_epsilon(self.epsilon),
+#                 self.delta,
+#                 rel_tol=1e-3), (
+#                     'Invalid settings of epsilon, delta, noise_parameters for '
+#                     'JointPLDPrivacyAccountant')
+#
+#         else:
+#             # Only two of epsilon, delta, noise parameters defined.
+#             # Compute remaining variable
+#             if self.noise_parameters:
+#                 composed_pld = self.get_composed_accountant(
+#                         self.mechanisms, self.noise_parameters,
+#                         self.pessimistic_estimate, self.sampling_probability,
+#                         self.use_connect_dots, self.value_discretization_interval,
+#                         self.num_compositions)
+#
+#                 if self.epsilon:
+#                     self.delta = composed_pld.get_delta_for_epsilon(
+#                         self.epsilon)
+#                 else:
+#                     self.epsilon = composed_pld.get_epsilon_for_delta(
+#                         self.delta)
+#
+#             else:
+#                 # Do binary search over large_epsilon. Within each iteration of the binary search
+#                 # we run an inner binary search to compute the noise parameter for each mechanism
+#                 # that enforce condition 1 from above.
+#                 def compute_delta(large_epsilon):
+#                     delta = self.get_composed_accountant(
+#                         self.mechanisms, self.compute_noise_paramters(large_epsilon), self.pessimistic_estimate,
+#                         self.sampling_probability, self.use_connect_dots, self.
+#                         value_discretization_interval, self.num_compositions,
+#                     ).get_delta_for_epsilon(self.epsilon)
+#
+#                     if delta < self.delta:
+#                         # large_epsilon was too small, i.e. noise was too large.
+#                         # We can decrease our starting max bound for the next noise parameter search
+#                         self.max_bounds = self.noise_parameters
+#                     else:
+#                         # large_epsilon was too large, i.e. noise was too small.
+#                         # We can increase our starting min bound for the next noise parameter search
+#                         self.min_bounds = self.noise_parameters
+#
+#                     return delta
+#
+#                 try:
+#                     self.large_epsilon = binary_search_function(
+#                         func=compute_delta,
+#                         func_monotonically_increasing=True,
+#                         target_value=self.delta,
+#                         min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
+#                         max_bound=min(MAX_BOUND_EPSILON, self.epsilon / min(*self.budget_proportions)),
+#                         rtol=RTOL_EPSILON,
+#                         confidence_threshold=
+#                         CONFIDENCE_THRESHOLD_EPSILON)
+#                 except Exception as e:
+#                     raise ValueError(
+#                         'Error occurred during binary search for '
+#                         'large_epsilon using PLD privacy accountant: '
+#                         f'{e}') from e
+#
+#     @staticmethod
+#     def get_composed_accountant(mechanisms, noise_parameters,
+#                                 pessimistic_estimate, sampling_probability,
+#                                 use_connect_dots,
+#                                 value_discretization_interval,
+#                                 num_compositions):
+#         composed_pld = None
+#         for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+#             if mechanism == 'gaussian':
+#                 pld = privacy_loss_distribution.from_gaussian_mechanism(
+#                     standard_deviation=noise_parameter,
+#                     sensitivity=1,
+#                     pessimistic_estimate=pessimistic_estimate,
+#                     sampling_prob=sampling_probability,
+#                     use_connect_dots=use_connect_dots,
+#                     value_discretization_interval=value_discretization_interval)
+#             elif mechanism == 'laplace':
+#                 pld = privacy_loss_distribution.from_laplace_mechanism(
+#                     parameter=noise_parameter,
+#                     sensitivity=1,
+#                     pessimistic_estimate=pessimistic_estimate,
+#                     sampling_prob=sampling_probability,
+#                     use_connect_dots=use_connect_dots,
+#                     value_discretization_interval=value_discretization_interval)
+#
+#             else:
+#                 raise ValueError(f'mechanism {mechanism} is not supported.')
+#
+#             if composed_pld is None:
+#                 composed_pld = pld.self_compose(num_compositions)
+#             else:
+#                 composed_pld = composed_pld.compose(pld.self_compose(num_compositions))
+#
+#         return composed_pld
+#
+#     def compute_noise_paramters(self, large_epsilon):
+#         noise_parameters = []
+#
+#         for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
+#             mechanism_epsilon = large_epsilon * p
+#             func = lambda noise_param: self.get_composed_accountant(
+#                 [mechanism], [noise_param], self.pessimistic_estimate,
+#                 self.sampling_probability, self.use_connect_dots, self.
+#                 value_discretization_interval, self.num_compositions,
+#             ).get_delta_for_epsilon(mechanism_epsilon)
+#             try:
+#                 noise_parameter = binary_search_function(
+#                     func=func,
+#                     func_monotonically_increasing=False,
+#                     target_value=self.delta,
+#                     min_bound=min_bound,
+#                     max_bound=max_bound,
+#                     rtol=RTOL_NOISE_PARAMETER,
+#                     confidence_threshold=
+#                     CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
+#             except Exception as e:
+#                 raise ValueError(
+#                     'Error occurred during binary search for '
+#                     'noise_parameter using PLD privacy accountant: '
+#                     f'{e}') from e
+#
+#             noise_parameters.append(noise_parameter)
+#
+#         self.noise_parameters = noise_parameters
+#         return noise_parameters
+#
+#
+# @dataclass
+# class JointPRVPrivacyAccountant(JointPrivacyAccountant):
+#     """
+#     Privacy Random Variable (PRV) accountant, for heterogeneous composition,
+#     using prv-accountant package.
+#     prv-accountant package: https://pypi.org/project/prv-accountant/
+#     Based on: “Numerical Composition of Differential Privacy”, Gopi et al.,
+#     2021, https://arxiv.org/pdf/2106.02848.pdf
+#     The PRV accountant methods compute_delta() and compute_epsilon() return
+#     a lower bound, an estimated value, and an upper bound for the delta and
+#     epsilon respectively. The estimated value is used for all further
+#     computations.
+#
+#     :param eps_error:
+#         Maximum permitted error in epsilon. Typically around 0.1.
+#     :param delta_error:
+#         Maximum error allowed in delta. Typically around delta * 1e-3
+#     """
+#     eps_error: Optional[float] = 0.07
+#     delta_error: Optional[float] = 1e-10
+#
+#     def __post_init__(self):
+#         super().__post_init__()
+#
+#         # epsilon, delta, noise_parameter all defined
+#         if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
+#             assert math.isclose(
+#                 self.get_composed_accountant(
+#                     self.mechanisms, self.noise_parameters,
+#                     self.sampling_probability, self.num_compositions,
+#                     self.eps_error,
+#                     self.delta_error).compute_delta(self.epsilon,
+#                                                     [self.num_compositions] * len(self.mechanisms))[1],
+#                 self.delta,
+#                 rel_tol=1e-3), (
+#                     'Invalid settings of epsilon, delta, noise_parameter'
+#                     'for PRVPrivacyAccountant')
+#
+#         else:
+#             if self.noise_parameters:
+#                 prv_acc = self.get_composed_accountant(
+#                     self.mechanisms, self.noise_parameters,
+#                     self.sampling_probability, self.num_compositions,
+#                     self.eps_error, self.delta_error)
+#
+#                 if self.epsilon:
+#                     # prv_acc.compute_delta() returns lower bound on delta,
+#                     # estimate of delta, and upper bound on delta.
+#                     # Estimate of delta is used.
+#                     (_, delta_estim,
+#                      _) = prv_acc.compute_delta(self.epsilon,
+#                                                 [self.num_compositions] * len(self.mechanisms))
+#                     self.delta = delta_estim
+#                 else:
+#                     # prv_acc.compute_epsilon() returns lower bound on epsilon,
+#                     # estimate of epsilon, and upper bound on epsion.
+#                     # Estimate of epsilon is used.
+#                     (_, epsilon_estim,
+#                      _) = prv_acc.compute_epsilon(self.delta,
+#                                                   [self.num_compositions] * len(self.mechanisms))
+#                     self.epsilon = epsilon_estim
+#
+#             else:
+#                 # Do binary search over large_epsilon. Within each iteration of the binary search
+#                 # we run an inner binary search to compute the noise parameter for each mechanism
+#                 # that enforce condition 1 from above.
+#                 def compute_delta(large_epsilon):
+#                     delta = self.get_composed_accountant(
+#                         self.mechanisms, self.compute_noise_paramters(large_epsilon),
+#                         self.sampling_probability, self.num_compositions,
+#                         self.eps_error, self.delta_error,
+#                     ).compute_delta(self.epsilon, [self.num_compositions] * len(self.mechanisms))[1]
+#
+#                     if delta < self.delta:
+#                         # large_epsilon was too small, i.e. noise was too large.
+#                         # We can decrease our starting max bound for the next noise parameter search
+#                         self.max_bounds = self.noise_parameters
+#                     else:
+#                         # large_epsilon was too large, i.e. noise was too small.
+#                         # We can increase our starting min bound for the next noise parameter search
+#                         self.min_bounds = self.noise_parameters
+#
+#                     return delta
+#
+#                 try:
+#                     self.large_epsilon = binary_search_function(
+#                         func=compute_delta,
+#                         func_monotonically_increasing=True,
+#                         target_value=self.delta,
+#                         min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
+#                         max_bound=min(MAX_BOUND_EPSILON, self.epsilon / min(*self.budget_proportions)),
+#                         rtol=RTOL_EPSILON,
+#                         confidence_threshold=
+#                         CONFIDENCE_THRESHOLD_EPSILON)
+#                 except Exception as e:
+#                     raise ValueError(
+#                         'Error occurred during binary search for '
+#                         'large_epsilon using PRV privacy accountant: '
+#                         f'{e}') from e
+#
+#     @staticmethod
+#     def get_composed_accountant(mechanisms, noise_parameters,
+#                                 sampling_probability, num_compositions,
+#                                 eps_error, delta_error):
+#
+#         prvs = []
+#         for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+#             if mechanism == 'gaussian':
+#                 prv = PoissonSubsampledGaussianMechanism(
+#                     sampling_probability=sampling_probability,
+#                     noise_multiplier=noise_parameter)
+#
+#             elif mechanism == 'laplace':
+#                 prv = LaplaceMechanism(mu=noise_parameter)
+#
+#             else:
+#                 raise ValueError(
+#                     f'Mechanism {mechanism} is not supported for PRV accountant')
+#
+#             prvs.append(prv)
+#
+#         acc_prv = PRVAccountant(prvs=prvs,
+#                                 max_self_compositions=[int(num_compositions)] * len(prvs),
+#                                 eps_error=eps_error,
+#                                 delta_error=delta_error)
+#
+#         return acc_prv
+#
+#     def compute_noise_paramters(self, large_epsilon):
+#         noise_parameters = []
+#
+#         for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
+#             mechanism_epsilon = large_epsilon * p
+#             func = lambda noise_param: self.get_composed_accountant(
+#                 [mechanism], [noise_param],
+#                     self.sampling_probability, self.num_compositions,
+#                     self.eps_error, self.delta_error,
+#             ).compute_delta(mechanism_epsilon, [self.num_compositions])[1]
+#             try:
+#                 noise_parameter = binary_search_function(
+#                     func=func,
+#                     func_monotonically_increasing=False,
+#                     target_value=self.delta,
+#                     min_bound=min_bound,
+#                     max_bound=max_bound,
+#                     rtol=RTOL_NOISE_PARAMETER,
+#                     confidence_threshold=
+#                     CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
+#             except Exception as e:
+#                 raise ValueError(
+#                     'Error occurred during binary search for '
+#                     'noise_parameter using PRV privacy accountant: '
+#                     f'{e}') from e
+#
+#             noise_parameters.append(noise_parameter)
+#
+#         self.noise_parameters = noise_parameters
+#         return noise_parameters
+#
+#
+# @dataclass
+# class JointRDPPrivacyAccountant(JointPrivacyAccountant):
+#     """
+#     Privacy accountant using Renyi differential privacy (RDP) from
+#     dp-accounting package.
+#     Implementation in dp-accounting: https://github.com/google/differential-privacy/blob/main/python/dp_accounting/rdp/rdp_privacy_accountant.py # pylint: disable=line-too-long
+#     The default neighbouring relation for the RDP account is "add or remove
+#     one". The default RDP orders used are:
+#     ([1 + x / 10. for x in range(1, 100)] + list(range(11, 64)) +
+#     [128, 256, 512, 1024]).
+#     """
+#
+#     def __post_init__(self):
+#         super().__post_init__()
+#
+#         # epsilon, delta, noise_parameters all defined
+#         if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
+#             assert math.isclose(
+#                 self.get_composed_accountant(
+#                     self.mechanisms, self.noise_parameters,
+#                     self.sampling_probability,
+#                     self.num_compositions).get_delta(self.epsilon),
+#                 self.delta,
+#                 rel_tol=1e-3), (
+#                     'Invalid settings of epsilon, delta, noise_parameter '
+#                     'for RDPPrivacyAccountant')
+#
+#         else:
+#             if self.noise_parameters:
+#
+#                 rdp_accountant = self.get_composed_accountant(
+#                     self.mechanisms, self.noise_parameters,
+#                     self.sampling_probability, self.num_compositions)
+#
+#                 if self.epsilon:
+#                     self.delta = rdp_accountant.get_delta(self.epsilon)
+#
+#                 else:
+#                     self.epsilon = rdp_accountant.get_epsilon(self.delta)
+#
+#             else:
+#                 # Do binary search over large_epsilon. Within each iteration of the binary search
+#                 # we run an inner binary search to compute the noise parameter for each mechanism
+#                 # that enforce condition 1 from above.
+#                 def compute_delta(large_epsilon):
+#                     delta = self.get_composed_accountant(
+#                         self.mechanisms, self.compute_noise_paramters(large_epsilon),
+#                         self.sampling_probability, self.num_compositions
+#                     ).get_delta(self.epsilon)
+#
+#                     if delta < self.delta:
+#                         # large_epsilon was too small, i.e. noise was too large.
+#                         # We can decrease our starting max bound for the next noise parameter search
+#                         self.max_bounds = self.noise_parameters
+#                     else:
+#                         # large_epsilon was too large, i.e. noise was too small.
+#                         # We can increase our starting min bound for the next noise parameter search
+#                         self.min_bounds = self.noise_parameters
+#
+#                     return delta
+#
+#                 try:
+#                     self.large_epsilon = binary_search_function(
+#                         func=compute_delta,
+#                         func_monotonically_increasing=True,
+#                         target_value=self.delta,
+#                         min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
+#                         max_bound=min(MAX_BOUND_EPSILON, self.epsilon / min(*self.budget_proportions)),
+#                         rtol=RTOL_EPSILON,
+#                         confidence_threshold=
+#                         CONFIDENCE_THRESHOLD_EPSILON)
+#                 except Exception as e:
+#                     raise ValueError(
+#                         'Error occurred during binary search for '
+#                         'large_epsilon using RDP privacy accountant: '
+#                         f'{e}') from e
+#
+#     @staticmethod
+#     def get_composed_accountant(mechanisms, noise_parameters,
+#                                 sampling_probability, num_compositions):
+#
+#         rdp_accountant = rdp_privacy_accountant.RdpAccountant()
+#         for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+#             if mechanism == 'gaussian':
+#                 event = dp_event.PoissonSampledDpEvent(
+#                     sampling_probability,
+#                     dp_event.GaussianDpEvent(noise_parameter))
+#
+#             elif mechanism == 'laplace':
+#                 event = dp_event.LaplaceDpEvent(noise_parameter)
+#                 pass
+#
+#             else:
+#                 raise ValueError(
+#                     f'Mechanism {mechanism} is not supported for Renyi accountant')
+#
+#             rdp_accountant = rdp_accountant.compose(
+#                 event, int(num_compositions))
+#
+#         return rdp_accountant
+#
+#     def compute_noise_paramters(self, large_epsilon):
+#         noise_parameters = []
+#
+#         for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
+#             mechanism_epsilon = large_epsilon * p
+#             func = lambda noise_param: self.get_composed_accountant(
+#                 [mechanism], [noise_param],
+#                 self.sampling_probability, self.num_compositions
+#             ).get_delta(mechanism_epsilon)
+#             try:
+#                 noise_parameter = binary_search_function(
+#                     func=func,
+#                     func_monotonically_increasing=False,
+#                     target_value=self.delta,
+#                     min_bound=min_bound,
+#                     max_bound=max_bound,
+#                     rtol=RTOL_NOISE_PARAMETER,
+#                     confidence_threshold=
+#                     CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
+#             except Exception as e:
+#                 raise ValueError(
+#                     'Error occurred during binary search for '
+#                     'noise_parameter using RDP privacy accountant: '
+#                     f'{e}') from e
+#
+#             noise_parameters.append(noise_parameter)
+#
+#         self.noise_parameters = noise_parameters
+#         return noise_parameters

--- a/pfl/privacy/joint_privacy_accountant.py
+++ b/pfl/privacy/joint_privacy_accountant.py
@@ -4,7 +4,6 @@ Privacy accountants for differential privacy.
 '''
 
 import math
-import time
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple, TypeVar
 
@@ -224,7 +223,6 @@ class JointPLDPrivacyAccountant(JointPrivacyAccountant):
                     return delta
 
                 try:
-                    start = time.time()
                     self.large_epsilon = binary_search_function(
                         func=compute_delta,
                         func_monotonically_increasing=True,
@@ -234,7 +232,6 @@ class JointPLDPrivacyAccountant(JointPrivacyAccountant):
                         rtol=RTOL_EPSILON,
                         confidence_threshold=
                         CONFIDENCE_THRESHOLD_EPSILON)
-                    print(f'Ran in {time.time() - start}')
                 except Exception as e:
                     raise ValueError(
                         'Error occurred during binary search for '
@@ -277,7 +274,6 @@ class JointPLDPrivacyAccountant(JointPrivacyAccountant):
         return composed_pld
 
     def compute_noise_paramters(self, large_epsilon):
-        start = time.time()
         noise_parameters = []
 
         for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
@@ -306,7 +302,6 @@ class JointPLDPrivacyAccountant(JointPrivacyAccountant):
             noise_parameters.append(noise_parameter)
 
         self.noise_parameters = noise_parameters
-        print(f"Computing noise parameters took {time.time() - start:.2f}s")
         return noise_parameters
 
 

--- a/pfl/privacy/joint_privacy_accountant.py
+++ b/pfl/privacy/joint_privacy_accountant.py
@@ -12,9 +12,16 @@ from dp_accounting.pld import privacy_loss_distribution
 from dp_accounting.rdp import rdp_privacy_accountant
 from prv_accountant import LaplaceMechanism, PoissonSubsampledGaussianMechanism, PRVAccountant
 
-from .privacy_accountant import (binary_search_function, MAX_BOUND_NOISE_PARAMETER, MIN_BOUND_NOISE_PARAMETER,
-                                 RTOL_NOISE_PARAMETER, CONFIDENCE_THRESHOLD_NOISE_PARAMETER,
-                                 PLDPrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant)
+from .privacy_accountant import (
+    CONFIDENCE_THRESHOLD_NOISE_PARAMETER,
+    MAX_BOUND_NOISE_PARAMETER,
+    MIN_BOUND_NOISE_PARAMETER,
+    RTOL_NOISE_PARAMETER,
+    PLDPrivacyAccountant,
+    PRVPrivacyAccountant,
+    RDPPrivacyAccountant,
+    binary_search_function,
+)
 
 MIN_BOUND_EPSILON = 0
 MAX_BOUND_EPSILON = 30
@@ -22,6 +29,9 @@ RTOL_EPSILON = 0.001
 CONFIDENCE_THRESHOLD_EPSILON = 1e-8
 
 PFL_ACCOUNTANT_TYPE = PLDPrivacyAccountant | PRVPrivacyAccountant | RDPPrivacyAccountant
+PFL_ACCOUNTANTS = {
+    PLDPrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant
+}
 
 
 @dataclass
@@ -46,7 +56,7 @@ class JointPrivacyAccountant:
         (total_epsilon, total_delta) DP.
     When the accountant classes to be used for each mechanism are different we
     can only use basic composition and the noise parameter for each mechanism is computed
-    separately so that mechanism_i is (total_epsilon * p_i, total_delta * p_i) DP
+    separately so that mechanism_i is (total_epsilon * p_i, total_delta * p_i) DP.
 
     2. The individual mechanism privacy budgets are known, i.e. mechanism_epsilons and
     mechanism_deltas are given. In this case we can compute the required noise parameter
@@ -113,6 +123,7 @@ class JointPrivacyAccountant:
     prv_accountant_kwargs: Optional[Dict] = None
 
     def __post_init__(self):
+        # Check if parameters are valid and reformat parameters to lists if needed
         self.check_valid_parameter_settings()
 
         # Set initial min and max bounds for the inner binary search
@@ -122,9 +133,19 @@ class JointPrivacyAccountant:
         if self.mechanism_epsilons is not None:
             # Individual mechanism privacy budgets are given and noise parameters
             # can be computed separately
-            self.noise_parameters = self.compute_for_each_mechanism(
+            noise_parameters = self.compute_for_each_mechanism(
                 mechanism_epsilons=self.mechanism_epsilons,
                 mechanism_deltas=self.mechanism_deltas)
+
+            if self.noise_parameters is None:
+                self.noise_parameters = noise_parameters
+            else:
+                assert all(
+                    math.isclose(sigma_computed, sigma_given)
+                    for sigma_computed, sigma_given in zip(
+                        noise_parameters, self.noise_parameters)
+                ), ('Noise parameters computed from mechanism epsilons and mechanism deltas'
+                    'do not match the provided noise parameters')
 
         if len(set(self.accountants)) == 1:
             # All accountant classes are the same, hence we can efficiently compose
@@ -135,45 +156,61 @@ class JointPrivacyAccountant:
             # Total epsilon, total delta, and noise parameters all defined. Check if
             # composition of mechanisms with given noise parameters satisfies
             # (total_epsilon, total_delta)-DP.
-            if [self.total_epsilon, self.total_delta, self.noise_parameters].count(None) == 0:
+            if [self.total_epsilon, self.total_delta,
+                    self.noise_parameters].count(None) == 0:
                 assert math.isclose(
-                    accountant_method(
-                         self.mechanisms, self.noise_parameters,
-                         self.num_compositions, self.sampling_probability,
-                         epsilon=self.total_epsilon, **accountant_kwargs),
+                    accountant_method(self.mechanisms,
+                                      self.noise_parameters,
+                                      self.num_compositions,
+                                      self.sampling_probability,
+                                      epsilon=self.total_epsilon,
+                                      **accountant_kwargs),
                     self.total_delta,
-                    rel_tol=1e-3), (
-                    'Invalid settings of epsilon, delta, noise_parameters')
+                    rel_tol=1e-3
+                ), ('Invalid settings of total epsilon, total delta, noise_parameters'
+                    )
             else:
                 if self.noise_parameters is not None:
+                    # Noise parameters are known, compute remaining privacy variable
                     if self.total_epsilon:
                         self.total_delta = accountant_method(
-                            self.mechanisms, self.noise_parameters,
-                            self.num_compositions, self.sampling_probability,
-                            epsilon=self.total_epsilon, **accountant_kwargs)
-                    else:
-                        self.total_epsilon = accountant_method(
-                            self.mechanisms, self.noise_parameters,
-                            self.num_compositions, self.sampling_probability,
-                            delta=self.total_delta, **accountant_kwargs)
-
-                else:
-                    # Do binary search over naive_epsilon. Within each iteration of the binary search
-                    # we run an inner binary search to compute the noise parameter for each mechanism
-                    # that enforce condition 1 from above.
-                    def compute_delta(naive_epsilon, delta_method=accountant_method):
-                        self.noise_parameters = self.compute_for_each_mechanism(
-                            mechanism_epsilons=[naive_epsilon * p for p in self.budget_proportions],
-                            mechanism_deltas=[self.total_delta * p for p in self.budget_proportions],
-                        )
-
-                        delta = delta_method(
                             self.mechanisms,
                             self.noise_parameters,
                             self.num_compositions,
                             self.sampling_probability,
                             epsilon=self.total_epsilon,
-                        )
+                            **accountant_kwargs)
+                    else:
+                        self.total_epsilon = accountant_method(
+                            self.mechanisms,
+                            self.noise_parameters,
+                            self.num_compositions,
+                            self.sampling_probability,
+                            delta=self.total_delta,
+                            **accountant_kwargs)
+
+                else:
+                    # Do binary search over naive_epsilon. Within each iteration of the binary search
+                    # we run an inner binary search to compute the noise parameter for each mechanism
+                    # that enforce condition A from above.
+                    def compute_delta(naive_epsilon,
+                                      delta_method=accountant_method):
+                        self.noise_parameters = self.compute_for_each_mechanism(
+                            mechanism_epsilons=[
+                                naive_epsilon * p
+                                for p in self.budget_proportions
+                            ],
+                            mechanism_deltas=[
+                                self.total_delta * p
+                                for p in self.budget_proportions
+                            ])
+
+                        delta = delta_method(self.mechanisms,
+                                             self.noise_parameters,
+                                             self.num_compositions,
+                                             self.sampling_probability,
+                                             epsilon=self.total_epsilon,
+                                             **accountant_kwargs)
 
                         if delta < self.total_delta:
                             # large_epsilon was too small, i.e. noise was too large.
@@ -191,11 +228,13 @@ class JointPrivacyAccountant:
                             func=compute_delta,
                             func_monotonically_increasing=True,
                             target_value=self.total_delta,
-                            min_bound=max(MIN_BOUND_EPSILON, self.total_epsilon),
-                            max_bound=min(MAX_BOUND_EPSILON, self.total_epsilon / min(*self.budget_proportions)),
+                            min_bound=max(MIN_BOUND_EPSILON,
+                                          self.total_epsilon),
+                            max_bound=min(
+                                MAX_BOUND_EPSILON, self.total_epsilon /
+                                max(*self.budget_proportions)),
                             rtol=RTOL_EPSILON,
-                            confidence_threshold=
-                            CONFIDENCE_THRESHOLD_EPSILON)
+                            confidence_threshold=CONFIDENCE_THRESHOLD_EPSILON)
                     except Exception as e:
                         raise ValueError(
                             'Error occurred during binary search for '
@@ -205,47 +244,95 @@ class JointPrivacyAccountant:
         else:
             # Accountant classes are different, we must use basic composition
             if self.mechanism_epsilons is not None:
-                self.total_epsilon = sum(self.mechanism_epsilons)
-                self.total_delta = sum(self.mechanism_deltas)
+                # noise parameters have already been computed, sum the privacy budgets
+                if self.total_epsilon is None:
+                    self.total_epsilon = sum(self.mechanism_epsilons)
+                else:
+                    assert math.isclose(
+                        self.total_epsilon, sum(self.mechanism_epsilons)
+                    ), ('Accountant classes are different, using basic composition.'
+                        'Computed mechanism epsilons do not sum to input total epsilon.'
+                        )
+
+                if self.total_delta is None:
+                    self.total_delta = sum(self.mechanism_deltas)
+                else:
+                    assert math.isclose(
+                        self.total_delta, sum(self.mechanism_deltas)
+                    ), ('Accountant classes are different, using basic composition.'
+                        'Computed mechanism deltas do not sum to input total delta.'
+                        )
+
             else:
-                if [self.total_epsilon, self.total_delta, self.noise_parameters].count(None) == 0:
+                if [
+                        self.total_epsilon, self.total_delta,
+                        self.noise_parameters
+                ].count(None) == 0:
                     # Check vals are correct
-                    pass
+                    self.mechanism_epsilons = [
+                        self.total_epsilon * p for p in self.budget_proportions
+                    ]
+                    self.mechanism_deltas = [
+                        self.total_delta * p for p in self.budget_proportions
+                    ]
+                    try:
+                        self.compute_for_each_mechanism(
+                            mechanism_epsilons=self.mechanism_epsilons,
+                            mechanism_deltas=self.mechanism_deltas,
+                            noise_parameters=self.noise_parameters)
+                    except AssertionError:
+                        raise ValueError(
+                            'Accountant classes are different, mechanism privacy budgets are computed'
+                            'using basic composition and the corresponding mechanism noise parameters '
+                            'do not match the provided noise parameters.')
 
                 else:
                     if self.noise_parameters is not None:
                         if self.total_epsilon:
-                            mechanism_epsilons = [self.total_epsilon * p for p in self.budget_proportions]
-                            deltas = self.compute_for_each_mechanism(
-                                mechanism_epsilons=mechanism_epsilons,
-                                noise_parameters=self.noise_parameters
-                            )
-                            self.total_delta = sum(deltas)
+                            self.mechanism_epsilons = [
+                                self.total_epsilon * p
+                                for p in self.budget_proportions
+                            ]
+                            self.mechanism_deltas = self.compute_for_each_mechanism(
+                                mechanism_epsilons=self.mechanism_epsilons,
+                                noise_parameters=self.noise_parameters)
+                            self.total_delta = sum(self.mechanism_deltas)
 
                         else:
-                            assert self.total_delta is not None
-                            mechanism_deltas = [self.total_delta * p for p in self.budget_proportions]
-                            epsilons = self.compute_for_each_mechanism(
-                                mechanism_deltas=mechanism_deltas,
-                                noise_parameters=self.noise_parameters
-                            )
-                            self.total_epsilon = sum(epsilons)
+                            self.mechanism_deltas = [
+                                self.total_delta * p
+                                for p in self.budget_proportions
+                            ]
+                            self.mechanism_epsilons = self.compute_for_each_mechanism(
+                                mechanism_deltas=self.mechanism_deltas,
+                                noise_parameters=self.noise_parameters)
+                            self.total_epsilon = sum(self.mechanism_epsilons)
 
                     else:
-                        mechanism_epsilons = [b * self.total_epsilon for b in self.budget_proportions]
-                        mechanism_deltas = [b * self.total_delta for b in self.budget_proportions]
+                        self.mechanism_epsilons = [
+                            b * self.total_epsilon
+                            for b in self.budget_proportions
+                        ]
+                        self.mechanism_deltas = [
+                            b * self.total_delta
+                            for b in self.budget_proportions
+                        ]
 
                         self.noise_parameters = self.compute_for_each_mechanism(
-                            mechanism_epsilons=mechanism_epsilons,
-                            mechanism_deltas=mechanism_deltas
-                        )
+                            mechanism_epsilons=self.mechanism_epsilons,
+                            mechanism_deltas=self.mechanism_deltas)
 
-    def compute_for_each_mechanism(self, mechanism_epsilons=None, mechanism_deltas=None, noise_parameters=None):
+    def compute_for_each_mechanism(self,
+                                   mechanism_epsilons=None,
+                                   mechanism_deltas=None,
+                                   noise_parameters=None):
         """
         Compute for each mechanism independently using the corresponding accountant.
         """
-
-        if noise_parameters is None:
+        if [mechanism_epsilons, mechanism_deltas,
+                noise_parameters].count(None) == 0:
+            computed_val = None
+        elif noise_parameters is None:
             computed_val = 'noise_parameter'
             noise_parameters = [None] * len(mechanism_epsilons)
         elif mechanism_deltas is None:
@@ -256,30 +343,41 @@ class JointPrivacyAccountant:
             mechanism_epsilons = [None] * len(mechanism_deltas)
 
         computed_vals = []
-        for mechanism, accountant_cls, n, p, e, d, s, min_bound, max_bound in zip(self.mechanisms,
-                                                                                  self.accountants,
-                                                                                  self.num_compositions,
-                                                                                  self.sampling_probability,
-                                                                                  mechanism_epsilons,
-                                                                                  mechanism_deltas,
-                                                                                  noise_parameters,
-                                                                                  self.min_bounds,
-                                                                                  self.max_bounds):
+        for mechanism, accountant_cls, n, p, e, d, s, min_bound, max_bound in zip(
+                self.mechanisms, self.accountants, self.num_compositions,
+                self.sampling_probability, mechanism_epsilons,
+                mechanism_deltas, noise_parameters, self.min_bounds,
+                self.max_bounds):
 
-            accountant = accountant_cls(mechanism=mechanism,
-                                        epsilon=e,
-                                        delta=d,
-                                        noise_parameter=s,
-                                        num_compositions=n,
-                                        sampling_probability=p,
-                                        min_bound_noise_parameter=min_bound,
-                                        max_bound_noise_parameter=max_bound,
-                                        **self.get_accountant_kwargs(accountant_cls))
-            computed_vals.append(getattr(accountant, computed_val))
+            accountant = accountant_cls(
+                mechanism=mechanism,
+                epsilon=e,
+                delta=d,
+                noise_parameter=s,
+                num_compositions=n,
+                sampling_probability=p,
+                min_bound_noise_parameter=min_bound,
+                max_bound_noise_parameter=max_bound,
+                **self.get_accountant_kwargs(accountant_cls))
+            if computed_val:
+                computed_vals.append(getattr(accountant, computed_val))
 
         return computed_vals
 
     def get_accountant_kwargs(self, accountant_cls):
+        if self.pld_accountant_kwargs is None:
+            self.pld_accountant_kwargs = {
+                'value_discretization_interval': 1e-4,
+                'use_connect_dots': True,
+                'pessimistic_estimate': True
+            }
+
+        if self.prv_accountant_kwargs is None:
+            self.prv_accountant_kwargs = {
+                'eps_error': 0.07,
+                'delta_error': 1e-10
+            }
+
         get_kwargs_accountant_map = {
             PLDPrivacyAccountant: self.pld_accountant_kwargs,
             PRVPrivacyAccountant: self.prv_accountant_kwargs,
@@ -296,16 +394,21 @@ class JointPrivacyAccountant:
         return get_method_accountant_map[accountant_cls]
 
     @staticmethod
-    def composed_pld_accountant(mechanisms, noise_parameters, num_compositions, sampling_probability,
+    def composed_pld_accountant(mechanisms,
+                                noise_parameters,
+                                num_compositions,
+                                sampling_probability,
                                 epsilon=None,
                                 delta=None,
-                                **kwargs
-                                ):
+                                **kwargs):
         assert [epsilon, delta].count(None) <= 1, (
             'At least one of epsilon and delta must be specified')
 
         composed_pld = None
-        for mechanism, noise_parameter, n, p in zip(mechanisms, noise_parameters, num_compositions, sampling_probability):
+        for mechanism, noise_parameter, n, p in zip(mechanisms,
+                                                    noise_parameters,
+                                                    num_compositions,
+                                                    sampling_probability):
             if mechanism == 'gaussian':
                 pld = privacy_loss_distribution.from_gaussian_mechanism(
                     standard_deviation=noise_parameter,
@@ -322,10 +425,9 @@ class JointPrivacyAccountant:
             else:
                 raise ValueError(f'mechanism {mechanism} is not supported.')
 
-            if composed_pld is None:
-                composed_pld = pld.self_compose(n)
-            else:
-                composed_pld = composed_pld.compose(pld.self_compose(n))
+            composed_pld = pld.self_compose(
+                n) if composed_pld is None else composed_pld.compose(
+                    pld.self_compose(n))
 
         if delta is None:
             return composed_pld.get_delta_for_epsilon(epsilon)
@@ -333,26 +435,33 @@ class JointPrivacyAccountant:
             return composed_pld.get_epsilon_for_delta(delta)
 
     @staticmethod
-    def composed_prv_accountant(mechanisms, noise_parameters, num_compositions, sampling_probability,
-                                epsilon=None, delta=None,
+    def composed_prv_accountant(mechanisms,
+                                noise_parameters,
+                                num_compositions,
+                                sampling_probability,
+                                epsilon=None,
+                                delta=None,
                                 **kwargs):
 
         assert [epsilon, delta].count(None) <= 1, (
             'At least one of epsilon and delta must be specified')
 
         prvs = []
-        for mechanism, noise_parameter, _, p in zip(mechanisms, noise_parameters, num_compositions, sampling_probability):
+        for mechanism, noise_parameter, _, p in zip(mechanisms,
+                                                    noise_parameters,
+                                                    num_compositions,
+                                                    sampling_probability):
             if mechanism == 'gaussian':
                 prv = PoissonSubsampledGaussianMechanism(
-                    sampling_probability=p,
-                    noise_multiplier=noise_parameter)
+                    sampling_probability=p, noise_multiplier=noise_parameter)
 
             elif mechanism == 'laplace':
                 prv = LaplaceMechanism(mu=noise_parameter)
 
             else:
                 raise ValueError(
-                    f'Mechanism {mechanism} is not supported for PRV accountant')
+                    f'Mechanism {mechanism} is not supported for PRV accountant'
+                )
 
             prvs.append(prv)
 
@@ -366,28 +475,34 @@ class JointPrivacyAccountant:
             return acc_prv.compute_epsilon(delta, num_compositions)[1]
 
     @staticmethod
-    def composed_rdp_accountant(mechanisms, noise_parameters, num_compositions, sampling_probability,
-                                epsilon=None, delta=None):
+    def composed_rdp_accountant(mechanisms,
+                                noise_parameters,
+                                num_compositions,
+                                sampling_probability,
+                                epsilon=None,
+                                delta=None):
 
         assert [epsilon, delta].count(None) <= 1, (
             'At least one of epsilon and delta must be specified')
 
         rdp_accountant = rdp_privacy_accountant.RdpAccountant()
-        for mechanism, noise_parameter, n, p in zip(mechanisms, noise_parameters, num_compositions, sampling_probability):
+        for mechanism, noise_parameter, n, p in zip(mechanisms,
+                                                    noise_parameters,
+                                                    num_compositions,
+                                                    sampling_probability):
             if mechanism == 'gaussian':
                 event = dp_event.PoissonSampledDpEvent(
-                    p,
-                    dp_event.GaussianDpEvent(noise_parameter))
+                    p, dp_event.GaussianDpEvent(noise_parameter))
 
             elif mechanism == 'laplace':
                 event = dp_event.LaplaceDpEvent(noise_parameter)
 
             else:
                 raise ValueError(
-                    f'Mechanism {mechanism} is not supported for Renyi accountant')
+                    f'Mechanism {mechanism} is not supported for Renyi accountant'
+                )
 
-            rdp_accountant = rdp_accountant.compose(
-                event, n)
+            rdp_accountant = rdp_accountant.compose(event, n)
 
         if delta is None:
             return rdp_accountant.get_delta(epsilon)
@@ -413,19 +528,19 @@ class JointPrivacyAccountant:
         # Check mechanisms
         self.mechanisms = [mechanism.lower() for mechanism in self.mechanisms]
         for mechanism in self.mechanisms:
-            assert mechanism in ['gaussian', 'laplace'], (
-                'Only gaussian and laplace mechanisms are supported.')
+            assert mechanism in [
+                'gaussian', 'laplace'
+            ], ('Only gaussian and laplace mechanisms are supported.')
 
         # Check accountants
         if isinstance(self.accountants, list):
             assert len(self.accountants) == len(self.mechanisms), (
-                'Accountants and mechanism names must have the same length'
-            )
+                'Accountants and mechanism names must have the same length')
         else:
             self.accountants = [self.accountants] * len(self.mechanisms)
 
-        assert all(isinstance(acc, PFL_ACCOUNTANT_TYPE) for acc in self.accountants), (
-            f'Accountants must be one of the accountant classes {PFL_ACCOUNTANT_TYPE}'
+        assert all(acc in PFL_ACCOUNTANTS for acc in self.accountants), (
+            f'Accountants must be one of the accountant classes {PFL_ACCOUNTANTS}'
         )
 
         # Check num_compositions
@@ -434,10 +549,12 @@ class JointPrivacyAccountant:
                 'Num compostitions and mechanism names must have the same length'
             )
         else:
-            self.num_compositions = [self.num_compositions] * len(self.mechanisms)
+            self.num_compositions = [self.num_compositions] * len(
+                self.mechanisms)
 
-        assert all(0 < n and isinstance(n, int) for n in self.num_compositions), (
-                'Number of compositions must be a positive integer')
+        assert all(n > 0 and isinstance(n, int)
+                   for n in self.num_compositions), (
+                       'Number of compositions must be a positive integer')
 
         # Check sampling_probability
         if isinstance(self.sampling_probability, list):
@@ -445,7 +562,8 @@ class JointPrivacyAccountant:
                 'Sampling probabilites and mechanism names must have the same length'
             )
         else:
-            self.sampling_probability = [self.sampling_probability] * len(self.mechanisms)
+            self.sampling_probability = [self.sampling_probability] * len(
+                self.mechanisms)
 
         assert all(0 <= p <= 1.0 for p in self.sampling_probability), (
             f'Sampling probabilities {self.sampling_probability} are invalid.'
@@ -462,18 +580,18 @@ class JointPrivacyAccountant:
                 'Delta should be a positive real value in range (0, 1)')
 
         # Check mechanism_epsilons and mechanism_deltas
-        if (self.mechanism_epsilons is not None) or (self.mechanism_deltas is not None):
-            assert (self.mechanism_epsilons is not None) and (self.mechanism_deltas is not None), (
-                'If one of mechanism_epsilons and mechanism_deltas is set then both must be.'
-            )
+        if (self.mechanism_epsilons is not None) or (self.mechanism_deltas
+                                                     is not None):
+            assert (self.mechanism_epsilons is not None) and (
+                self.mechanism_deltas is not None
+            ), ('If one of mechanism_epsilons and mechanism_deltas is set then both must be.'
+                )
 
             assert all(eps >= 0 for eps in self.mechanism_epsilons), (
-                'All mechanism epsilons must be non-negative real values'
-            )
+                'All mechanism epsilons must be non-negative real values')
 
             assert all(0 < delta < 1 for delta in self.mechanism_deltas), (
-                'All mechanism deltas must be positive real values in (0, 1)'
-            )
+                'All mechanism deltas must be positive real values in (0, 1)')
 
             assert len(self.mechanism_epsilons) == len(self.mechanisms), (
                 'Mechanism epsilons and mechanism names must have the same length'
@@ -486,494 +604,47 @@ class JointPrivacyAccountant:
         # Check budget_proportions
         if self.budget_proportions is not None:
             assert len(self.mechanisms) == len(self.budget_proportions), (
-                'Mechansim names and budget proportions must have the same length'
+                'Mechanism names and budget proportions must have the same length'
             )
 
             assert all(0 < p < 1.0 for p in self.budget_proportions), (
-                    f'Budget proportions {self.budget_proportions} are invalid.'
-                    'Must be in range (0, 1)')
+                f'Budget proportions {self.budget_proportions} are invalid.'
+                'Must be in range (0, 1)')
 
-            assert math.isclose(sum(self.budget_proportions), 1, rel_tol=1e-3), (
-                'Privacy budget proportions must sum to 1.'
-            )
+            assert math.isclose(
+                sum(self.budget_proportions), 1,
+                rel_tol=1e-3), ('Privacy budget proportions must sum to 1.')
         else:
-            self.budget_proportions = [1 / len(self.mechanisms)] * len(self.mechanisms)
+            self.budget_proportions = [1 / len(self.mechanisms)] * len(
+                self.mechanisms)
 
         # Check noise_parameters
         if self.noise_parameters is not None:
-            assert all(0 < s for s in self.noise_parameters), (
-                    'All noise parameters must be positive real values.')
+            assert all(s > 0 for s in self.noise_parameters), (
+                'All noise parameters must be positive real values.')
 
         # Check noise_scale
         if self.noise_scale <= 0 or self.noise_scale > 1.0:
             raise ValueError("noise_scale must be in range (0,1]")
 
-        assert [
-            self.total_epsilon, self.total_delta, self.noise_parameters
-        ].count(None) <= 1, (
-            f'At least two of total epsilon ({self.total_epsilon}),'
-            f'total delta ({self.total_delta}) and noise parameters ({self.noise_parameters})'
-            'must be defined for a joint privacy accountant')
-
-#
-#
-#
-# @dataclass
-# class JointPLDPrivacyAccountant(JointPrivacyAccountant):
-#     """
-#     Uses Privacy Loss Distribution (PLD) privacy accountant, from dp-accounting
-#     package for each mechanism.
-#
-#     :param value_discretization_interval:
-#         The length of the dicretization interval for the privacy loss
-#         distribution. Rounding will occur to integer multiples of
-#         value_discretization_interval. Smaller values yield more accurate
-#         estimates of the privacy loss, while incurring higher compute and
-#         memory. Hence, larger values decrease computation time. Note that the
-#         accountant algorithm maintains similar error bounds as the value of
-#         value_discretization_interval is changed.
-#     :param use_connect_dots:
-#         boolean indicating whether or not to use Connect-the-Dots algorithm by
-#         Doroshenko et al., which gives tighter discrete approximations of PLDs.
-#     :param pessimistic_estimate:
-#         boolean indicating whether rounding used in PLD algorithm results in
-#         epsilon-hockey stick divergence computation yielding upper estimate to
-#         real value.
-#     :param log_mass_truncation_bound:
-#         The natural log of probability mass that may be discarded from noise
-#         distribution.
-#         Larger values will increase the error.
-#     """
-#     value_discretization_interval: float = 1e-4
-#     use_connect_dots: bool = True
-#     pessimistic_estimate: bool = True
-#     log_mass_truncation_bound: float = -50
-#
-#     def __post_init__(self):
-#         super().__post_init__()
-#
-#         # Epsilon, delta, noise parameter all defined. Nothing to do.
-#         if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
-#             assert math.isclose(
-#                 self.get_composed_accountant(
-#                     self.mechanisms, self.noise_parameters,
-#                     self.pessimistic_estimate, self.sampling_probability,
-#                     self.use_connect_dots, self.value_discretization_interval,
-#                     self.num_compositions).get_delta_for_epsilon(self.epsilon),
-#                 self.delta,
-#                 rel_tol=1e-3), (
-#                     'Invalid settings of epsilon, delta, noise_parameters for '
-#                     'JointPLDPrivacyAccountant')
-#
-#         else:
-#             # Only two of epsilon, delta, noise parameters defined.
-#             # Compute remaining variable
-#             if self.noise_parameters:
-#                 composed_pld = self.get_composed_accountant(
-#                         self.mechanisms, self.noise_parameters,
-#                         self.pessimistic_estimate, self.sampling_probability,
-#                         self.use_connect_dots, self.value_discretization_interval,
-#                         self.num_compositions)
-#
-#                 if self.epsilon:
-#                     self.delta = composed_pld.get_delta_for_epsilon(
-#                         self.epsilon)
-#                 else:
-#                     self.epsilon = composed_pld.get_epsilon_for_delta(
-#                         self.delta)
-#
-#             else:
-#                 # Do binary search over large_epsilon. Within each iteration of the binary search
-#                 # we run an inner binary search to compute the noise parameter for each mechanism
-#                 # that enforce condition 1 from above.
-#                 def compute_delta(large_epsilon):
-#                     delta = self.get_composed_accountant(
-#                         self.mechanisms, self.compute_noise_paramters(large_epsilon), self.pessimistic_estimate,
-#                         self.sampling_probability, self.use_connect_dots, self.
-#                         value_discretization_interval, self.num_compositions,
-#                     ).get_delta_for_epsilon(self.epsilon)
-#
-#                     if delta < self.delta:
-#                         # large_epsilon was too small, i.e. noise was too large.
-#                         # We can decrease our starting max bound for the next noise parameter search
-#                         self.max_bounds = self.noise_parameters
-#                     else:
-#                         # large_epsilon was too large, i.e. noise was too small.
-#                         # We can increase our starting min bound for the next noise parameter search
-#                         self.min_bounds = self.noise_parameters
-#
-#                     return delta
-#
-#                 try:
-#                     self.large_epsilon = binary_search_function(
-#                         func=compute_delta,
-#                         func_monotonically_increasing=True,
-#                         target_value=self.delta,
-#                         min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
-#                         max_bound=min(MAX_BOUND_EPSILON, self.epsilon / min(*self.budget_proportions)),
-#                         rtol=RTOL_EPSILON,
-#                         confidence_threshold=
-#                         CONFIDENCE_THRESHOLD_EPSILON)
-#                 except Exception as e:
-#                     raise ValueError(
-#                         'Error occurred during binary search for '
-#                         'large_epsilon using PLD privacy accountant: '
-#                         f'{e}') from e
-#
-#     @staticmethod
-#     def get_composed_accountant(mechanisms, noise_parameters,
-#                                 pessimistic_estimate, sampling_probability,
-#                                 use_connect_dots,
-#                                 value_discretization_interval,
-#                                 num_compositions):
-#         composed_pld = None
-#         for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
-#             if mechanism == 'gaussian':
-#                 pld = privacy_loss_distribution.from_gaussian_mechanism(
-#                     standard_deviation=noise_parameter,
-#                     sensitivity=1,
-#                     pessimistic_estimate=pessimistic_estimate,
-#                     sampling_prob=sampling_probability,
-#                     use_connect_dots=use_connect_dots,
-#                     value_discretization_interval=value_discretization_interval)
-#             elif mechanism == 'laplace':
-#                 pld = privacy_loss_distribution.from_laplace_mechanism(
-#                     parameter=noise_parameter,
-#                     sensitivity=1,
-#                     pessimistic_estimate=pessimistic_estimate,
-#                     sampling_prob=sampling_probability,
-#                     use_connect_dots=use_connect_dots,
-#                     value_discretization_interval=value_discretization_interval)
-#
-#             else:
-#                 raise ValueError(f'mechanism {mechanism} is not supported.')
-#
-#             if composed_pld is None:
-#                 composed_pld = pld.self_compose(num_compositions)
-#             else:
-#                 composed_pld = composed_pld.compose(pld.self_compose(num_compositions))
-#
-#         return composed_pld
-#
-#     def compute_noise_paramters(self, large_epsilon):
-#         noise_parameters = []
-#
-#         for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
-#             mechanism_epsilon = large_epsilon * p
-#             func = lambda noise_param: self.get_composed_accountant(
-#                 [mechanism], [noise_param], self.pessimistic_estimate,
-#                 self.sampling_probability, self.use_connect_dots, self.
-#                 value_discretization_interval, self.num_compositions,
-#             ).get_delta_for_epsilon(mechanism_epsilon)
-#             try:
-#                 noise_parameter = binary_search_function(
-#                     func=func,
-#                     func_monotonically_increasing=False,
-#                     target_value=self.delta,
-#                     min_bound=min_bound,
-#                     max_bound=max_bound,
-#                     rtol=RTOL_NOISE_PARAMETER,
-#                     confidence_threshold=
-#                     CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
-#             except Exception as e:
-#                 raise ValueError(
-#                     'Error occurred during binary search for '
-#                     'noise_parameter using PLD privacy accountant: '
-#                     f'{e}') from e
-#
-#             noise_parameters.append(noise_parameter)
-#
-#         self.noise_parameters = noise_parameters
-#         return noise_parameters
-#
-#
-# @dataclass
-# class JointPRVPrivacyAccountant(JointPrivacyAccountant):
-#     """
-#     Privacy Random Variable (PRV) accountant, for heterogeneous composition,
-#     using prv-accountant package.
-#     prv-accountant package: https://pypi.org/project/prv-accountant/
-#     Based on: “Numerical Composition of Differential Privacy”, Gopi et al.,
-#     2021, https://arxiv.org/pdf/2106.02848.pdf
-#     The PRV accountant methods compute_delta() and compute_epsilon() return
-#     a lower bound, an estimated value, and an upper bound for the delta and
-#     epsilon respectively. The estimated value is used for all further
-#     computations.
-#
-#     :param eps_error:
-#         Maximum permitted error in epsilon. Typically around 0.1.
-#     :param delta_error:
-#         Maximum error allowed in delta. Typically around delta * 1e-3
-#     """
-#     eps_error: Optional[float] = 0.07
-#     delta_error: Optional[float] = 1e-10
-#
-#     def __post_init__(self):
-#         super().__post_init__()
-#
-#         # epsilon, delta, noise_parameter all defined
-#         if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
-#             assert math.isclose(
-#                 self.get_composed_accountant(
-#                     self.mechanisms, self.noise_parameters,
-#                     self.sampling_probability, self.num_compositions,
-#                     self.eps_error,
-#                     self.delta_error).compute_delta(self.epsilon,
-#                                                     [self.num_compositions] * len(self.mechanisms))[1],
-#                 self.delta,
-#                 rel_tol=1e-3), (
-#                     'Invalid settings of epsilon, delta, noise_parameter'
-#                     'for PRVPrivacyAccountant')
-#
-#         else:
-#             if self.noise_parameters:
-#                 prv_acc = self.get_composed_accountant(
-#                     self.mechanisms, self.noise_parameters,
-#                     self.sampling_probability, self.num_compositions,
-#                     self.eps_error, self.delta_error)
-#
-#                 if self.epsilon:
-#                     # prv_acc.compute_delta() returns lower bound on delta,
-#                     # estimate of delta, and upper bound on delta.
-#                     # Estimate of delta is used.
-#                     (_, delta_estim,
-#                      _) = prv_acc.compute_delta(self.epsilon,
-#                                                 [self.num_compositions] * len(self.mechanisms))
-#                     self.delta = delta_estim
-#                 else:
-#                     # prv_acc.compute_epsilon() returns lower bound on epsilon,
-#                     # estimate of epsilon, and upper bound on epsion.
-#                     # Estimate of epsilon is used.
-#                     (_, epsilon_estim,
-#                      _) = prv_acc.compute_epsilon(self.delta,
-#                                                   [self.num_compositions] * len(self.mechanisms))
-#                     self.epsilon = epsilon_estim
-#
-#             else:
-#                 # Do binary search over large_epsilon. Within each iteration of the binary search
-#                 # we run an inner binary search to compute the noise parameter for each mechanism
-#                 # that enforce condition 1 from above.
-#                 def compute_delta(large_epsilon):
-#                     delta = self.get_composed_accountant(
-#                         self.mechanisms, self.compute_noise_paramters(large_epsilon),
-#                         self.sampling_probability, self.num_compositions,
-#                         self.eps_error, self.delta_error,
-#                     ).compute_delta(self.epsilon, [self.num_compositions] * len(self.mechanisms))[1]
-#
-#                     if delta < self.delta:
-#                         # large_epsilon was too small, i.e. noise was too large.
-#                         # We can decrease our starting max bound for the next noise parameter search
-#                         self.max_bounds = self.noise_parameters
-#                     else:
-#                         # large_epsilon was too large, i.e. noise was too small.
-#                         # We can increase our starting min bound for the next noise parameter search
-#                         self.min_bounds = self.noise_parameters
-#
-#                     return delta
-#
-#                 try:
-#                     self.large_epsilon = binary_search_function(
-#                         func=compute_delta,
-#                         func_monotonically_increasing=True,
-#                         target_value=self.delta,
-#                         min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
-#                         max_bound=min(MAX_BOUND_EPSILON, self.epsilon / min(*self.budget_proportions)),
-#                         rtol=RTOL_EPSILON,
-#                         confidence_threshold=
-#                         CONFIDENCE_THRESHOLD_EPSILON)
-#                 except Exception as e:
-#                     raise ValueError(
-#                         'Error occurred during binary search for '
-#                         'large_epsilon using PRV privacy accountant: '
-#                         f'{e}') from e
-#
-#     @staticmethod
-#     def get_composed_accountant(mechanisms, noise_parameters,
-#                                 sampling_probability, num_compositions,
-#                                 eps_error, delta_error):
-#
-#         prvs = []
-#         for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
-#             if mechanism == 'gaussian':
-#                 prv = PoissonSubsampledGaussianMechanism(
-#                     sampling_probability=sampling_probability,
-#                     noise_multiplier=noise_parameter)
-#
-#             elif mechanism == 'laplace':
-#                 prv = LaplaceMechanism(mu=noise_parameter)
-#
-#             else:
-#                 raise ValueError(
-#                     f'Mechanism {mechanism} is not supported for PRV accountant')
-#
-#             prvs.append(prv)
-#
-#         acc_prv = PRVAccountant(prvs=prvs,
-#                                 max_self_compositions=[int(num_compositions)] * len(prvs),
-#                                 eps_error=eps_error,
-#                                 delta_error=delta_error)
-#
-#         return acc_prv
-#
-#     def compute_noise_paramters(self, large_epsilon):
-#         noise_parameters = []
-#
-#         for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
-#             mechanism_epsilon = large_epsilon * p
-#             func = lambda noise_param: self.get_composed_accountant(
-#                 [mechanism], [noise_param],
-#                     self.sampling_probability, self.num_compositions,
-#                     self.eps_error, self.delta_error,
-#             ).compute_delta(mechanism_epsilon, [self.num_compositions])[1]
-#             try:
-#                 noise_parameter = binary_search_function(
-#                     func=func,
-#                     func_monotonically_increasing=False,
-#                     target_value=self.delta,
-#                     min_bound=min_bound,
-#                     max_bound=max_bound,
-#                     rtol=RTOL_NOISE_PARAMETER,
-#                     confidence_threshold=
-#                     CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
-#             except Exception as e:
-#                 raise ValueError(
-#                     'Error occurred during binary search for '
-#                     'noise_parameter using PRV privacy accountant: '
-#                     f'{e}') from e
-#
-#             noise_parameters.append(noise_parameter)
-#
-#         self.noise_parameters = noise_parameters
-#         return noise_parameters
-#
-#
-# @dataclass
-# class JointRDPPrivacyAccountant(JointPrivacyAccountant):
-#     """
-#     Privacy accountant using Renyi differential privacy (RDP) from
-#     dp-accounting package.
-#     Implementation in dp-accounting: https://github.com/google/differential-privacy/blob/main/python/dp_accounting/rdp/rdp_privacy_accountant.py # pylint: disable=line-too-long
-#     The default neighbouring relation for the RDP account is "add or remove
-#     one". The default RDP orders used are:
-#     ([1 + x / 10. for x in range(1, 100)] + list(range(11, 64)) +
-#     [128, 256, 512, 1024]).
-#     """
-#
-#     def __post_init__(self):
-#         super().__post_init__()
-#
-#         # epsilon, delta, noise_parameters all defined
-#         if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
-#             assert math.isclose(
-#                 self.get_composed_accountant(
-#                     self.mechanisms, self.noise_parameters,
-#                     self.sampling_probability,
-#                     self.num_compositions).get_delta(self.epsilon),
-#                 self.delta,
-#                 rel_tol=1e-3), (
-#                     'Invalid settings of epsilon, delta, noise_parameter '
-#                     'for RDPPrivacyAccountant')
-#
-#         else:
-#             if self.noise_parameters:
-#
-#                 rdp_accountant = self.get_composed_accountant(
-#                     self.mechanisms, self.noise_parameters,
-#                     self.sampling_probability, self.num_compositions)
-#
-#                 if self.epsilon:
-#                     self.delta = rdp_accountant.get_delta(self.epsilon)
-#
-#                 else:
-#                     self.epsilon = rdp_accountant.get_epsilon(self.delta)
-#
-#             else:
-#                 # Do binary search over large_epsilon. Within each iteration of the binary search
-#                 # we run an inner binary search to compute the noise parameter for each mechanism
-#                 # that enforce condition 1 from above.
-#                 def compute_delta(large_epsilon):
-#                     delta = self.get_composed_accountant(
-#                         self.mechanisms, self.compute_noise_paramters(large_epsilon),
-#                         self.sampling_probability, self.num_compositions
-#                     ).get_delta(self.epsilon)
-#
-#                     if delta < self.delta:
-#                         # large_epsilon was too small, i.e. noise was too large.
-#                         # We can decrease our starting max bound for the next noise parameter search
-#                         self.max_bounds = self.noise_parameters
-#                     else:
-#                         # large_epsilon was too large, i.e. noise was too small.
-#                         # We can increase our starting min bound for the next noise parameter search
-#                         self.min_bounds = self.noise_parameters
-#
-#                     return delta
-#
-#                 try:
-#                     self.large_epsilon = binary_search_function(
-#                         func=compute_delta,
-#                         func_monotonically_increasing=True,
-#                         target_value=self.delta,
-#                         min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
-#                         max_bound=min(MAX_BOUND_EPSILON, self.epsilon / min(*self.budget_proportions)),
-#                         rtol=RTOL_EPSILON,
-#                         confidence_threshold=
-#                         CONFIDENCE_THRESHOLD_EPSILON)
-#                 except Exception as e:
-#                     raise ValueError(
-#                         'Error occurred during binary search for '
-#                         'large_epsilon using RDP privacy accountant: '
-#                         f'{e}') from e
-#
-#     @staticmethod
-#     def get_composed_accountant(mechanisms, noise_parameters,
-#                                 sampling_probability, num_compositions):
-#
-#         rdp_accountant = rdp_privacy_accountant.RdpAccountant()
-#         for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
-#             if mechanism == 'gaussian':
-#                 event = dp_event.PoissonSampledDpEvent(
-#                     sampling_probability,
-#                     dp_event.GaussianDpEvent(noise_parameter))
-#
-#             elif mechanism == 'laplace':
-#                 event = dp_event.LaplaceDpEvent(noise_parameter)
-#                 pass
-#
-#             else:
-#                 raise ValueError(
-#                     f'Mechanism {mechanism} is not supported for Renyi accountant')
-#
-#             rdp_accountant = rdp_accountant.compose(
-#                 event, int(num_compositions))
-#
-#         return rdp_accountant
-#
-#     def compute_noise_paramters(self, large_epsilon):
-#         noise_parameters = []
-#
-#         for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
-#             mechanism_epsilon = large_epsilon * p
-#             func = lambda noise_param: self.get_composed_accountant(
-#                 [mechanism], [noise_param],
-#                 self.sampling_probability, self.num_compositions
-#             ).get_delta(mechanism_epsilon)
-#             try:
-#                 noise_parameter = binary_search_function(
-#                     func=func,
-#                     func_monotonically_increasing=False,
-#                     target_value=self.delta,
-#                     min_bound=min_bound,
-#                     max_bound=max_bound,
-#                     rtol=RTOL_NOISE_PARAMETER,
-#                     confidence_threshold=
-#                     CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
-#             except Exception as e:
-#                 raise ValueError(
-#                     'Error occurred during binary search for '
-#                     'noise_parameter using RDP privacy accountant: '
-#                     f'{e}') from e
-#
-#             noise_parameters.append(noise_parameter)
-#
-#         self.noise_parameters = noise_parameters
-#         return noise_parameters
+        # If mechanism privacy budget are specified and accountant classes differ
+        # then total epsilon and total delta are both inferred using basic composition.
+        # Otherwise, at least two of total epsilon, total delta or noise parameters must
+        # be provided to infer the other
+        if self.mechanism_deltas is None:
+            assert [
+                self.total_epsilon, self.total_delta, self.noise_parameters
+            ].count(None) <= 1, (
+                f'At least two of total epsilon ({self.total_epsilon}),'
+                f'total delta ({self.total_delta}) and noise parameters ({self.noise_parameters})'
+                'must be defined for this usage of the joint privacy accountant.'
+            )
+        else:
+            if len(set(self.accountants)) == 1:
+                assert [
+                    self.total_epsilon, self.total_delta
+                ].count(None) <= 1, (
+                    f'At least one of total epsilon ({self.total_epsilon}) and'
+                    f'total delta ({self.total_delta})'
+                    'must be defined for this usage of the joint privacy accountant.'
+                )

--- a/pfl/privacy/joint_privacy_accountant.py
+++ b/pfl/privacy/joint_privacy_accountant.py
@@ -213,11 +213,11 @@ class JointPrivacyAccountant:
                                              **accountant_kwargs)
 
                         if delta < self.total_delta:
-                            # large_epsilon was too small, i.e. noise was too large.
+                            # naive_epsilon was too small, i.e. noise was too large.
                             # We can decrease our starting max bound for the next noise parameter search
                             self.max_bounds = self.noise_parameters
                         else:
-                            # large_epsilon was too large, i.e. noise was too small.
+                            # naive_epsilon was too large, i.e. noise was too small.
                             # We can increase our starting min bound for the next noise parameter search
                             self.min_bounds = self.noise_parameters
 
@@ -238,7 +238,7 @@ class JointPrivacyAccountant:
                     except Exception as e:
                         raise ValueError(
                             'Error occurred during binary search for '
-                            'large_epsilon: '
+                            'naive_epsilon: '
                             f'{e}') from e
 
         else:

--- a/pfl/privacy/joint_privacy_accountant.py
+++ b/pfl/privacy/joint_privacy_accountant.py
@@ -1,0 +1,329 @@
+# Copyright © 2023-2024 Apple Inc.
+'''
+Privacy accountants for differential privacy.
+'''
+
+import math
+import time
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple, TypeVar
+
+from dp_accounting import dp_event
+from dp_accounting.pld import privacy_loss_distribution
+from dp_accounting.rdp import rdp_privacy_accountant
+from prv_accountant import LaplaceMechanism, PoissonSubsampledGaussianMechanism, PRVAccountant
+
+from .privacy_accountant import binary_search_function
+
+MIN_BOUND_NOISE_PARAMETER = 0
+MAX_BOUND_NOISE_PARAMETER = 100
+RTOL_NOISE_PARAMETER = 0.001
+CONFIDENCE_THRESHOLD_NOISE_PARAMETER = 1e-8
+
+MIN_BOUND_EPSILON = 0
+MAX_BOUND_EPSILON = 30
+RTOL_EPSILON = 0.001
+CONFIDENCE_THRESHOLD_EPSILON = 1e-8
+
+
+@dataclass
+class JointPrivacyAccountant:
+    """
+    Tracks the privacy loss over multiple composition steps with multiple
+    mechanisms simultaneously. Either two or three of the variables epsilon,
+    delta and noise_parameters must be defined.
+
+    If all three are defined a check will be performed to make sure a valid set of
+    variable values has been provided.
+
+    If two are defined, the remaining variable can be computed. In the case that
+    epsilon and delta are defined then the budget_proportions parameter
+    must be provided, specifying what fraction of the total budget each
+    mechanism is allocated. For budget_proportions = [p_1, p_2, ...]
+    the noise parameters are then computed as follows. We find large_epsilon
+    and noise parameters [sigma_1, sigma_2, ...] such that the following two
+    constraints hold:
+    1. For each i, mechanism_i with noise parameter sigma_i is (large_epsilon * p_i, delta)
+    DP after all composition steps
+    2. The composition of all mechanisms over all steps is (epsilon, delta) DP
+
+    :param num_compositions:
+        Maximum number of compositions to be performed with each mechanism.
+    :param sampling_probability:
+       Maximum probability of sampling each entity being privatized. E.g. if
+       the unit of privacy is one device, this is the probability of each
+       device participating.
+    :param mechanisms:
+        The list of noise mechanisms to be used, each can be either Gaussian or Laplace.
+    :param epsilon:
+        The privacy loss random variable. It controls how much the output of
+        the mechanism can vary between two neighboring databases.
+    :param delta:
+        The probability that all privacy will be lost.
+    :param budget_proportions:
+        List specifying the proportion of the total (epsilon, delta) privacy budget
+        each mechanism is allocated.
+    :param noise_parameters:
+        The parameters for DP noise for each mechanism. For the Gaussian
+        mechanism, the noise parameter is the standard deviation of the noise.
+        For the Laplace mechanism, the noise parameter is the scale of the noise.
+    :param noise_scale:
+        A value \\in [0, 1] multiplied with the standard deviation of the noise
+        to be added for privatization. Typically used to experiment with lower
+        sampling probabilities when it is not possible or desirable to increase
+        the population size of the units being privatized, e.g. user devices.
+    """
+    num_compositions: int
+    sampling_probability: float
+    mechanisms: List[str]
+    epsilon: Optional[float] = None
+    delta: Optional[float] = None
+    budget_proportions: Optional[List[float]] = None
+    noise_parameters: Optional[List[float]] = None
+    noise_scale: float = 1.0
+
+    def __post_init__(self):
+        assert [
+            self.epsilon, self.delta, self.noise_parameters
+        ].count(None) <= 1, (
+            f'At least two of epsilon ({self.epsilon}),'
+            f'delta ({self.delta}) and noise parameters ({self.noise_parameters})'
+            'must be defined for a joint privacy accountant')
+        if self.noise_scale <= 0 or self.noise_scale > 1.0:
+            raise ValueError("noise_scale must be in range (0,1]")
+        assert (
+            self.sampling_probability >= 0
+            and self.sampling_probability <= 1.0), (
+                f'Sampling probability {self.sampling_probability} is invalid.'
+                'Must be in range [0, 1]')
+        assert self.num_compositions > 0 and isinstance(
+            self.num_compositions,
+            int), ('Number of compositions must be a positive integer')
+        if self.noise_parameters is not None:
+            for noise_parameter in self.noise_parameters:
+                assert noise_parameter > 0, (
+                    'All noise parameters must be positive real values.')
+        if self.epsilon is not None:
+            assert self.epsilon >= 0, (
+                'Epsilon must be a non-negative real value')
+        if self.delta is not None:
+            assert self.delta > 0 and self.delta < 1, (
+                'Delta should be a positive real value in range (0, 1)')
+
+        self.mechanisms = [mechanism.lower() for mechanism in self.mechanisms]
+
+    @property
+    def cohort_noise_parameters(self):
+        """
+        Noise parameters to be used on a cohort of users.
+        Noise scale is considered.
+        """
+        return [noise_parameter * self.noise_scale for noise_parameter in self.noise_parameters]
+
+
+@dataclass
+class JointPLDPrivacyAccountant(JointPrivacyAccountant):
+    """
+    Uses Privacy Loss Distribution (PLD) privacy accountant, from dp-accounting
+    package for each mechanism.
+
+    :param value_discretization_interval:
+        The length of the dicretization interval for the privacy loss
+        distribution. Rounding will occur to integer multiples of
+        value_discretization_interval. Smaller values yield more accurate
+        estimates of the privacy loss, while incurring higher compute and
+        memory. Hence, larger values decrease computation time. Note that the
+        accountant algorithm maintains similar error bounds as the value of
+        value_discretization_interval is changed.
+    :param use_connect_dots:
+        boolean indicating whether or not to use Connect-the-Dots algorithm by
+        Doroshenko et al., which gives tighter discrete approximations of PLDs.
+    :param pessimistic_estimate:
+        boolean indicating whether rounding used in PLD algorithm results in
+        epsilon-hockey stick divergence computation yielding upper estimate to
+        real value.
+    :param log_mass_truncation_bound:
+        The natural log of probability mass that may be discarded from noise
+        distribution.
+        Larger values will increase the error.
+    """
+    value_discretization_interval: float = 1e-4
+    use_connect_dots: bool = True
+    pessimistic_estimate: bool = True
+    log_mass_truncation_bound: float = -50
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.min_bounds = [MIN_BOUND_NOISE_PARAMETER] * len(self.mechanisms)
+        self.max_bounds = [MAX_BOUND_NOISE_PARAMETER] * len(self.mechanisms)
+
+        for mechanism in self.mechanisms:
+            assert mechanism in [
+                'gaussian', 'laplace'
+            ], ('Only gaussian and laplace mechanisms are supported.')
+
+        if self.budget_proportions:
+            assert len(self.mechanisms) == len(self.budget_proportions), (
+                'Mechansim names and budget proportions must have the same length'
+            )
+
+            assert math.isclose(sum(self.budget_proportions), 1, rel_tol=1e-3), (
+                'Privacy budget proportions must sum to 1.'
+            )
+
+        # Epsilon, delta, noise parameter all defined. Nothing to do.
+        if [self.epsilon, self.delta, self.noise_parameters].count(None) == 0:
+            assert math.isclose(
+                self.get_composed_accountant(
+                    self.mechanisms, self.noise_parameters,
+                    self.pessimistic_estimate, self.sampling_probability,
+                    self.use_connect_dots, self.value_discretization_interval,
+                    self.num_compositions).get_delta_for_epsilon(self.epsilon),
+                self.delta,
+                rel_tol=1e-3), (
+                    'Invalid settings of epsilon, delta, noise_parameters for '
+                    'JointPLDPrivacyAccountant')
+
+        else:
+            # Only two of epsilon, delta, noise parameters defined.
+            # Compute remaining variable
+            if self.noise_parameters:
+                composed_pld = self.get_composed_accountant(
+                        self.mechanisms, self.noise_parameters,
+                        self.pessimistic_estimate, self.sampling_probability,
+                        self.use_connect_dots, self.value_discretization_interval,
+                        self.num_compositions)
+
+                if self.epsilon:
+                    self.delta = composed_pld.get_delta_for_epsilon(
+                        self.epsilon)
+                else:
+                    self.epsilon = composed_pld.get_epsilon_for_delta(
+                        self.delta)
+
+            else:
+                # Do binary search over large_epsilon. Within each iteration of the binary search
+                # we run an inner binary search to compute the noise parameter for each mechanism
+                # that enforce condition 1 from above.
+                def compute_delta(large_epsilon):
+                    delta = self.get_composed_accountant(
+                        self.mechanisms, self.compute_noise_paramters(large_epsilon), self.pessimistic_estimate,
+                        self.sampling_probability, self.use_connect_dots, self.
+                        value_discretization_interval, self.num_compositions,
+                    ).get_delta_for_epsilon(self.epsilon)
+
+                    if delta < self.delta:
+                        # large_epsilon was too small, i.e. noise was too large.
+                        # We can decrease our starting max bound for the next noise parameter search
+                        self.max_bounds = self.noise_parameters
+                    else:
+                        # large_epsilon was too large, i.e. noise was too small.
+                        # We can increase our starting min bound for the next noise parameter search
+                        self.min_bounds = self.noise_parameters
+
+                    return delta
+
+                try:
+                    start = time.time()
+                    self.large_epsilon = binary_search_function(
+                        func=compute_delta,
+                        func_monotonically_increasing=True,
+                        target_value=self.delta,
+                        min_bound=max(MIN_BOUND_EPSILON, self.epsilon),
+                        max_bound=min(MAX_BOUND_EPSILON, self.epsilon / min(*self.budget_proportions)),
+                        rtol=RTOL_EPSILON,
+                        confidence_threshold=
+                        CONFIDENCE_THRESHOLD_EPSILON)
+                    print(f'Ran in {time.time() - start}')
+                except Exception as e:
+                    raise ValueError(
+                        'Error occurred during binary search for '
+                        'large_epsilon using PLD privacy accountant: '
+                        f'{e}') from e
+
+    @staticmethod
+    def get_composed_accountant(mechanisms, noise_parameters,
+                                pessimistic_estimate, sampling_probability,
+                                use_connect_dots,
+                                value_discretization_interval,
+                                num_compositions):
+        composed_pld = None
+        for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+            if mechanism == 'gaussian':
+                pld = privacy_loss_distribution.from_gaussian_mechanism(
+                    standard_deviation=noise_parameter,
+                    sensitivity=1,
+                    pessimistic_estimate=pessimistic_estimate,
+                    sampling_prob=sampling_probability,
+                    use_connect_dots=use_connect_dots,
+                    value_discretization_interval=value_discretization_interval)
+            elif mechanism == 'laplace':
+                pld = privacy_loss_distribution.from_laplace_mechanism(
+                    parameter=noise_parameter,
+                    sensitivity=1,
+                    pessimistic_estimate=pessimistic_estimate,
+                    sampling_prob=sampling_probability,
+                    use_connect_dots=use_connect_dots,
+                    value_discretization_interval=value_discretization_interval)
+
+            else:
+                raise ValueError(f'mechanism {mechanism} is not supported.')
+
+            if composed_pld is None:
+                composed_pld = pld.self_compose(num_compositions)
+            else:
+                composed_pld = composed_pld.compose(pld.self_compose(num_compositions))
+
+        return composed_pld
+
+    def compute_noise_paramters(self, large_epsilon):
+        start = time.time()
+        noise_parameters = []
+
+        for mechanism, p, min_bound, max_bound in zip(self.mechanisms, self.budget_proportions, self.min_bounds, self.max_bounds):
+            mechanism_epsilon = large_epsilon * p
+            func = lambda noise_param: self.get_composed_accountant(
+                [mechanism], [noise_param], self.pessimistic_estimate,
+                self.sampling_probability, self.use_connect_dots, self.
+                value_discretization_interval, self.num_compositions,
+            ).get_delta_for_epsilon(mechanism_epsilon)
+            try:
+                noise_parameter = binary_search_function(
+                    func=func,
+                    func_monotonically_increasing=False,
+                    target_value=self.delta,
+                    min_bound=min_bound,
+                    max_bound=max_bound,
+                    rtol=RTOL_NOISE_PARAMETER,
+                    confidence_threshold=
+                    CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
+            except Exception as e:
+                raise ValueError(
+                    'Error occurred during binary search for '
+                    'noise_parameter using PLD privacy accountant: '
+                    f'{e}') from e
+
+            noise_parameters.append(noise_parameter)
+
+        self.noise_parameters = noise_parameters
+        print(f"Computing noise parameters took {time.time() - start:.2f}s")
+        return noise_parameters
+
+
+def main():
+    epsilon = 2
+    delta = 1e-8
+    num_compositions = 100
+    sample_prob = 0.1
+    mechanisms = ['gaussian', 'gaussian']
+    budget_proportions = [0.25, 0.75]
+
+    accountant = JointPLDPrivacyAccountant(num_compositions, sample_prob, mechanisms,
+                                           epsilon=epsilon, delta=delta, budget_proportions=budget_proportions)
+
+    print(accountant.noise_parameters)
+    print(accountant.large_epsilon)
+
+
+if __name__ == '__main__':
+    main()

--- a/pfl/privacy/joint_privacy_accountant.py
+++ b/pfl/privacy/joint_privacy_accountant.py
@@ -5,7 +5,7 @@ Privacy accountants for differential privacy.
 
 import math
 from dataclasses import dataclass
-from typing import Callable, List, Optional, Tuple, TypeVar
+from typing import List, Optional
 
 from dp_accounting import dp_event
 from dp_accounting.pld import privacy_loss_distribution
@@ -55,10 +55,11 @@ class JointPrivacyAccountant:
     :param mechanisms:
         The list of noise mechanisms to be used, each can be either Gaussian or Laplace.
     :param epsilon:
-        The privacy loss random variable. It controls how much the output of
-        the mechanism can vary between two neighboring databases.
+        The privacy loss random variable. The total epsilon allowed for
+        the composition of all the mechanisms.
     :param delta:
-        The probability that all privacy will be lost.
+        The probability that all privacy will be lost. The total delta allowed for
+        the composition of all the mechanisms.
     :param budget_proportions:
         List specifying the proportion of the total (epsilon, delta) privacy budget
         each mechanism is allocated.
@@ -464,6 +465,7 @@ class JointPRVPrivacyAccountant(JointPrivacyAccountant):
 
         self.noise_parameters = noise_parameters
         return noise_parameters
+
 
 @dataclass
 class JointRDPPrivacyAccountant(JointPrivacyAccountant):

--- a/pfl/privacy/joint_privacy_accountant.py
+++ b/pfl/privacy/joint_privacy_accountant.py
@@ -301,15 +301,15 @@ class JointPLDPrivacyAccountant(JointPrivacyAccountant):
                                                       self.min_bounds,
                                                       self.max_bounds):
             mechanism_epsilon = large_epsilon * p
-            func = lambda noise_param: self.get_composed_accountant(
-                [mechanism],
+            func = lambda noise_param, mech=mechanism, mech_epsilon=mechanism_epsilon: self.get_composed_accountant(
+                [mech],
                 [noise_param],
                 self.pessimistic_estimate,
                 self.sampling_probability,
                 self.use_connect_dots,
                 self.value_discretization_interval,
                 self.num_compositions,
-            ).get_delta_for_epsilon(mechanism_epsilon)
+            ).get_delta_for_epsilon(mech_epsilon)
             try:
                 noise_parameter = binary_search_function(
                     func=func,
@@ -474,14 +474,14 @@ class JointPRVPrivacyAccountant(JointPrivacyAccountant):
                                                       self.min_bounds,
                                                       self.max_bounds):
             mechanism_epsilon = large_epsilon * p
-            func = lambda noise_param: self.get_composed_accountant(
-                [mechanism],
+            func = lambda noise_param, mech=mechanism, mech_epsilon=mechanism_epsilon: self.get_composed_accountant(
+                [mech],
                 [noise_param],
                 self.sampling_probability,
                 self.num_compositions,
                 self.eps_error,
                 self.delta_error,
-            ).compute_delta(mechanism_epsilon, [self.num_compositions])[1]
+            ).compute_delta(mech_epsilon, [self.num_compositions])[1]
             try:
                 noise_parameter = binary_search_function(
                     func=func,
@@ -615,9 +615,9 @@ class JointRDPPrivacyAccountant(JointPrivacyAccountant):
                                                       self.min_bounds,
                                                       self.max_bounds):
             mechanism_epsilon = large_epsilon * p
-            func = lambda noise_param: self.get_composed_accountant(
-                [mechanism], [noise_param], self.sampling_probability, self.
-                num_compositions).get_delta(mechanism_epsilon)
+            func = lambda noise_param, mech=mechanism, mech_epsilon=mechanism_epsilon: self.get_composed_accountant(
+                [mech], [noise_param], self.sampling_probability, self.
+                num_compositions).get_delta(mech_epsilon)
             try:
                 noise_parameter = binary_search_function(
                     func=func,

--- a/pfl/privacy/privacy_accountant.py
+++ b/pfl/privacy/privacy_accountant.py
@@ -63,8 +63,8 @@ class PrivacyAccountant:
     delta: Optional[float] = None
     noise_parameter: Optional[float] = None
     noise_scale: float = 1.0
-    min_bound_noise_parameter: float = None
-    max_bound_noise_parameter: float = None
+    min_bound_noise_parameter: Optional[float] = None
+    max_bound_noise_parameter: Optional[float] = None
 
     def __post_init__(self):
         assert [
@@ -100,7 +100,6 @@ class PrivacyAccountant:
 
         if self.max_bound_noise_parameter is None:
             self.max_bound_noise_parameter = MAX_BOUND_NOISE_PARAMETER
-
 
     @property
     def cohort_noise_parameter(self):
@@ -511,4 +510,3 @@ def binary_search_function(func: Callable,
         'Binary search did not converge')
 
     return guess
-

--- a/pfl/privacy/privacy_accountant.py
+++ b/pfl/privacy/privacy_accountant.py
@@ -49,6 +49,12 @@ class PrivacyAccountant:
         to be added for privatization. Typically used to experiment with lower
         sampling probabilities when it is not possible or desirable to increase
         the population size of the units being privatized, e.g. user devices.
+    :param min_bound_noise_parameter:
+        Used to manually set the lower bound of the binary search
+        used to find the correct noise parameter
+    :param max_bound_noise_parameter:
+        Used to manually set the upper bound of the binary search
+        used to find the correct noise parameter
     """
     num_compositions: int
     sampling_probability: float
@@ -57,6 +63,8 @@ class PrivacyAccountant:
     delta: Optional[float] = None
     noise_parameter: Optional[float] = None
     noise_scale: float = 1.0
+    min_bound_noise_parameter: float = None
+    max_bound_noise_parameter: float = None
 
     def __post_init__(self):
         assert [
@@ -86,6 +94,13 @@ class PrivacyAccountant:
                 'Delta should be a positive real value in range (0, 1)')
 
         self.mechanism = self.mechanism.lower()
+
+        if self.min_bound_noise_parameter is None:
+            self.min_bound_noise_parameter = MIN_BOUND_NOISE_PARAMETER
+
+        if self.max_bound_noise_parameter is None:
+            self.max_bound_noise_parameter = MAX_BOUND_NOISE_PARAMETER
+
 
     @property
     def cohort_noise_parameter(self):
@@ -191,8 +206,8 @@ class PLDPrivacyAccountant(PrivacyAccountant):
                         func_monotonically_increasing=
                         func_monotonically_increasing,
                         target_value=self.delta,
-                        min_bound=MIN_BOUND_NOISE_PARAMETER,
-                        max_bound=MAX_BOUND_NOISE_PARAMETER,
+                        min_bound=self.min_bound_noise_parameter,
+                        max_bound=self.max_bound_noise_parameter,
                         rtol=RTOL_NOISE_PARAMETER,
                         confidence_threshold=
                         CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
@@ -309,8 +324,8 @@ class PRVPrivacyAccountant(PrivacyAccountant):
                         func_monotonically_increasing=
                         func_monotonically_increasing,
                         target_value=self.delta,
-                        min_bound=MIN_BOUND_NOISE_PARAMETER,
-                        max_bound=MAX_BOUND_NOISE_PARAMETER,
+                        min_bound=self.min_bound_noise_parameter,
+                        max_bound=self.max_bound_noise_parameter,
                         rtol=RTOL_NOISE_PARAMETER,
                         confidence_threshold=
                         CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
@@ -396,8 +411,8 @@ class RDPPrivacyAccountant(PrivacyAccountant):
                         func_monotonically_increasing=
                         func_monotonically_increasing,
                         target_value=self.delta,
-                        min_bound=MIN_BOUND_NOISE_PARAMETER,
-                        max_bound=MAX_BOUND_NOISE_PARAMETER,
+                        min_bound=self.min_bound_noise_parameter,
+                        max_bound=self.max_bound_noise_parameter,
                         rtol=RTOL_NOISE_PARAMETER,
                         confidence_threshold=
                         CONFIDENCE_THRESHOLD_NOISE_PARAMETER)
@@ -496,3 +511,4 @@ def binary_search_function(func: Callable,
         'Binary search did not converge')
 
     return guess
+

--- a/tests/privacy/test_joint_privacy_accountant.py
+++ b/tests/privacy/test_joint_privacy_accountant.py
@@ -77,7 +77,7 @@ class TestPrivacyAccountants:
 
     @pytest.mark.parametrize(
         'accountant_class, fn_expected_delta, max_bound',
-        [(JointPLDPrivacyAccountant, get_expected_delta_pld, 15)])
+        [(JointPLDPrivacyAccountant, get_expected_delta_pld, 20)])
     @pytest.mark.parametrize(
         'num_compositions, sampling_probability, epsilon, delta, noise_parameters, noise_scale, mechanisms, budget_proportions',  # pylint: disable=line-too-long
         [(1000, 0.01, 2, None, [0.76, 1], 1.0, ['gaussian', 'gaussian'], None),
@@ -125,26 +125,26 @@ class TestPrivacyAccountants:
                     for pld, p in zip(plds, budget_proportions):
                         np.testing.assert_almost_equal(pld.get_epsilon_for_delta(delta), accountant.large_epsilon * p, decimal=2)
 
-    # @pytest.mark.xfail(raises=(ValueError, AssertionError), strict=True)
-    # @pytest.mark.parametrize('accountant_class', [(PLDPrivacyAccountant),
-    #                                               (PRVPrivacyAccountant),
-    #                                               (RDPPrivacyAccountant)])
-    # @pytest.mark.parametrize(
-    #     'num_compositions, sampling_probability, epsilon, delta, noise_parameter, noise_scale, mechanism',  # pylint: disable=line-too-long
-    #     [(100, 0.1, 2, None, None, 1.0, 'gaussian'),
-    #      (100, 0.1, None, None, None, 1.0, 'laplace'),
-    #      (100, 0.1, 2, 1e-8, None, 1.2, 'gaussian'),
-    #      (100, 0.1, 2, 1e-8, None, 1.0, 'bernoulli'),
-    #      (100, 0.1, 2, 1e-8, 10, 1.0, 'gaussian')])
-    # def test_fail(self, num_compositions, sampling_probability, epsilon, delta,
-    #               noise_parameter, noise_scale, mechanism, accountant_class):
-    #     accountant_class(
-    #         num_compositions=num_compositions,
-    #         sampling_probability=sampling_probability,
-    #         mechanism=mechanism,
-    #         epsilon=epsilon,
-    #         delta=delta,
-    #         noise_parameter=noise_parameter,
-    #         noise_scale=noise_scale,
-    #     )
+    @pytest.mark.xfail(raises=(ValueError, AssertionError), strict=True)
+    @pytest.mark.parametrize('accountant_class', [JointPLDPrivacyAccountant])
+    @pytest.mark.parametrize(
+        'num_compositions, sampling_probability, epsilon, delta, noise_parameters, noise_scale, mechanisms, budget_proportions',  # pylint: disable=line-too-long
+        [(100, 0.1, 2, None, None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+         (100, 0.1, None, None, None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+         (100, 0.1, 2, 1e-8, None, 1.2, ['gaussian', 'gaussian'], [0.5, 0.5]),
+         (100, 0.1, 2, 1e-8, None, 1.0, ['bernoulli', 'gaussian'], [0.5, 0.5]),
+         (100, 0.1, 2, 1e-8, [10, 10], 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+         (100, 0.1, 2, 1e-8, None, 0.8, ['gaussian', 'gaussian'], [0.1, 0.75])])
+    def test_fail(self, num_compositions, sampling_probability, epsilon, delta,
+                  noise_parameters, noise_scale, mechanisms, budget_proportions, accountant_class):
+        accountant_class(
+            num_compositions=num_compositions,
+            sampling_probability=sampling_probability,
+            mechanisms=mechanisms,
+            epsilon=epsilon,
+            delta=delta,
+            budget_proportions=budget_proportions,
+            noise_parameters=noise_parameters,
+            noise_scale=noise_scale,
+        )
 

--- a/tests/privacy/test_joint_privacy_accountant.py
+++ b/tests/privacy/test_joint_privacy_accountant.py
@@ -1,0 +1,150 @@
+# Copyright © 2023-2024 Apple Inc.
+'''
+Test privacy accountants for DP in privacy_accountant.py.
+'''
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from dp_accounting import dp_event
+from dp_accounting.pld import privacy_loss_distribution
+from dp_accounting.rdp import rdp_privacy_accountant
+from prv_accountant import LaplaceMechanism, PoissonSubsampledGaussianMechanism, PRVAccountant
+
+from pfl.privacy import JointPLDPrivacyAccountant
+
+
+@pytest.fixture()
+def num_compositions():
+    return [2, 10, 1e2, 1e4]
+
+
+@pytest.fixture()
+def sampling_probability():
+    return [1e-8, 1e-5, 1e-2, 1e-1, 0.5]
+
+
+@pytest.fixture()
+def epsilon():
+    return [0.5, 2, 5, 20]
+
+
+@pytest.fixture()
+def delta():
+    return [1e-12, 1e-6, 1e-2]
+
+
+@pytest.fixture()
+def sigma():
+    return []
+
+
+def get_expected_delta_pld(noise_parameters, sampling_probability,
+                           num_compositions, mechanisms, epsilon):
+
+    plds = []
+    for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+        if mechanism == 'gaussian':
+            pld = privacy_loss_distribution.from_gaussian_mechanism(
+                standard_deviation=noise_parameter,
+                sensitivity=1,
+                sampling_prob=sampling_probability,
+            ).self_compose(num_compositions)
+        elif mechanism == 'laplace':
+            pld = privacy_loss_distribution.from_laplace_mechanism(
+                parameter=noise_parameter,
+                sensitivity=1,
+                sampling_prob=sampling_probability,
+            ).self_compose(num_compositions)
+        else:
+            raise ValueError(f'Mechanism {mechanism} is not a valid value.')
+
+        plds.append(pld)
+
+    composed_pld = None
+    for pld in plds:
+        if composed_pld:
+            composed_pld = composed_pld.compose(pld)
+        else:
+            composed_pld = pld
+
+    expected_delta = composed_pld.get_delta_for_epsilon(epsilon)
+    return expected_delta, plds
+
+
+class TestPrivacyAccountants:
+
+    @pytest.mark.parametrize(
+        'accountant_class, fn_expected_delta, max_bound',
+        [(JointPLDPrivacyAccountant, get_expected_delta_pld, 15)])
+    @pytest.mark.parametrize(
+        'num_compositions, sampling_probability, epsilon, delta, noise_parameters, noise_scale, mechanisms, budget_proportions',  # pylint: disable=line-too-long
+        [(1000, 0.01, 2, None, [0.76, 1], 1.0, ['gaussian', 'gaussian'], None),
+         (100, 0.1, None, 1e-8, [0.5, 0.5], 0.5, ['gaussian', 'laplace'], None),
+         (100, 0.1, 2, 1e-8, None, 0.8, ['gaussian', 'gaussian'], [0.25, 0.75])])
+    def test(self, num_compositions, sampling_probability, epsilon, delta,
+             noise_parameters, noise_scale, mechanisms, budget_proportions,
+             accountant_class, fn_expected_delta, max_bound):
+        # these are patches for hyperparameters for the binary search for the
+        # noise parameter - these settings speed up the binary search for tests
+        with patch(
+                'pfl.privacy.joint_privacy_accountant.MIN_BOUND_NOISE_PARAMETER',
+                new=2), patch(
+                    'pfl.privacy.joint_privacy_accountant.MAX_BOUND_NOISE_PARAMETER',
+                    new=max_bound), patch(
+                        'pfl.privacy.joint_privacy_accountant.MIN_BOUND_EPSILON',
+                        new=2.5), patch(
+                            'pfl.privacy.joint_privacy_accountant.MAX_BOUND_EPSILON',
+                            new=2.6):
+            with patch('pfl.privacy.joint_privacy_accountant.RTOL_NOISE_PARAMETER',
+                       new=0.1), patch(
+                            'pfl.privacy.joint_privacy_accountant.RTOL_EPSILON',
+                            new=0.1):
+                accountant = accountant_class(
+                    num_compositions=num_compositions,
+                    sampling_probability=sampling_probability,
+                    mechanisms=mechanisms,
+                    epsilon=epsilon,
+                    delta=delta,
+                    budget_proportions=budget_proportions,
+                    noise_parameters=noise_parameters,
+                    noise_scale=noise_scale)
+                noise_parameters = ([cohort_noise_parameter / noise_scale
+                                     for cohort_noise_parameter in accountant.cohort_noise_parameters])
+
+                expected_delta, plds = fn_expected_delta(noise_parameters,
+                                                         sampling_probability,
+                                                         num_compositions, mechanisms,
+                                                         accountant.epsilon)
+
+                np.testing.assert_almost_equal(accountant.delta,
+                                               expected_delta)
+
+                if budget_proportions:
+                    for pld, p in zip(plds, budget_proportions):
+                        np.testing.assert_almost_equal(pld.get_epsilon_for_delta(delta), accountant.large_epsilon * p, decimal=2)
+
+    # @pytest.mark.xfail(raises=(ValueError, AssertionError), strict=True)
+    # @pytest.mark.parametrize('accountant_class', [(PLDPrivacyAccountant),
+    #                                               (PRVPrivacyAccountant),
+    #                                               (RDPPrivacyAccountant)])
+    # @pytest.mark.parametrize(
+    #     'num_compositions, sampling_probability, epsilon, delta, noise_parameter, noise_scale, mechanism',  # pylint: disable=line-too-long
+    #     [(100, 0.1, 2, None, None, 1.0, 'gaussian'),
+    #      (100, 0.1, None, None, None, 1.0, 'laplace'),
+    #      (100, 0.1, 2, 1e-8, None, 1.2, 'gaussian'),
+    #      (100, 0.1, 2, 1e-8, None, 1.0, 'bernoulli'),
+    #      (100, 0.1, 2, 1e-8, 10, 1.0, 'gaussian')])
+    # def test_fail(self, num_compositions, sampling_probability, epsilon, delta,
+    #               noise_parameter, noise_scale, mechanism, accountant_class):
+    #     accountant_class(
+    #         num_compositions=num_compositions,
+    #         sampling_probability=sampling_probability,
+    #         mechanism=mechanism,
+    #         epsilon=epsilon,
+    #         delta=delta,
+    #         noise_parameter=noise_parameter,
+    #         noise_scale=noise_scale,
+    #     )
+

--- a/tests/privacy/test_joint_privacy_accountant.py
+++ b/tests/privacy/test_joint_privacy_accountant.py
@@ -12,7 +12,7 @@ from dp_accounting.pld import privacy_loss_distribution
 from dp_accounting.rdp import rdp_privacy_accountant
 from prv_accountant import LaplaceMechanism, PoissonSubsampledGaussianMechanism, PRVAccountant
 
-from pfl.privacy import JointPLDPrivacyAccountant, JointPRVPrivacyAccountant, JointRDPPrivacyAccountant
+from pfl.privacy import JointPrivacyAccountant, PLDPrivacyAccountant, PRVPrivacyAccountant, RDPPrivacyAccountant
 
 
 @pytest.fixture()
@@ -41,22 +41,29 @@ def sigma():
 
 
 def get_expected_delta_pld(noise_parameters, sampling_probability,
-                           num_compositions, mechanisms, epsilon):
+                           num_compositions, mechanisms, epsilon, accountants,
+                           mechanism_epsilons):
 
+    if not isinstance(sampling_probability, list):
+        sampling_probability = [sampling_probability] * len(mechanisms)
+    if not isinstance(num_compositions, list):
+        num_compositions = [num_compositions] * len(mechanisms)
     plds = []
-    for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+    for mechanism, noise_parameter, n, p in zip(mechanisms, noise_parameters,
+                                                num_compositions,
+                                                sampling_probability):
         if mechanism == 'gaussian':
             pld = privacy_loss_distribution.from_gaussian_mechanism(
                 standard_deviation=noise_parameter,
                 sensitivity=1,
-                sampling_prob=sampling_probability,
-            ).self_compose(num_compositions)
+                sampling_prob=p,
+            ).self_compose(n)
         elif mechanism == 'laplace':
             pld = privacy_loss_distribution.from_laplace_mechanism(
                 parameter=noise_parameter,
                 sensitivity=1,
-                sampling_prob=sampling_probability,
-            ).self_compose(num_compositions)
+                sampling_prob=p,
+            ).self_compose(n)
         else:
             raise ValueError(f'Mechanism {mechanism} is not a valid value.')
 
@@ -71,13 +78,20 @@ def get_expected_delta_pld(noise_parameters, sampling_probability,
 
 
 def get_expected_delta_prv(noise_parameters, sampling_probability,
-                           num_compositions, mechanisms, epsilon):
+                           num_compositions, mechanisms, epsilon, accountants,
+                           mechanism_epsilons):
+
+    if not isinstance(sampling_probability, list):
+        sampling_probability = [sampling_probability] * len(mechanisms)
+    if not isinstance(num_compositions, list):
+        num_compositions = [num_compositions] * len(mechanisms)
+
     prvs = []
-    for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+    for mechanism, noise_parameter, p in zip(mechanisms, noise_parameters,
+                                             sampling_probability):
         if mechanism == 'gaussian':
             prv = PoissonSubsampledGaussianMechanism(
-                sampling_probability=sampling_probability,
-                noise_multiplier=noise_parameter)
+                sampling_probability=p, noise_multiplier=noise_parameter)
 
         elif mechanism == 'laplace':
             prv = LaplaceMechanism(mu=noise_parameter)
@@ -89,33 +103,39 @@ def get_expected_delta_prv(noise_parameters, sampling_probability,
         prvs.append(prv)
 
     acc_prv = PRVAccountant(prvs=prvs,
-                            max_self_compositions=[int(num_compositions)] *
-                            len(prvs),
+                            max_self_compositions=num_compositions,
                             eps_error=0.07,
                             delta_error=1e-10)
 
-    _, expected_delta, _ = acc_prv.compute_delta(
-        epsilon, [int(num_compositions)] * len(prvs))
+    _, expected_delta, _ = acc_prv.compute_delta(epsilon, num_compositions)
 
     individual_prvs = [
         PRVAccountant(prvs=prv,
-                      max_self_compositions=int(num_compositions),
+                      max_self_compositions=n,
                       eps_error=0.07,
-                      delta_error=1e-10) for prv in prvs
+                      delta_error=1e-10)
+        for prv, n in zip(prvs, num_compositions)
     ]
     return expected_delta, individual_prvs
 
 
 def get_expected_delta_rdp(noise_parameters, sampling_probability,
-                           num_compositions, mechanisms, epsilon):
+                           num_compositions, mechanisms, epsilon, accountants,
+                           mechanism_epsilons):
+
+    if not isinstance(sampling_probability, list):
+        sampling_probability = [sampling_probability] * len(mechanisms)
+    if not isinstance(num_compositions, list):
+        num_compositions = [num_compositions] * len(mechanisms)
 
     rdps = []
     full_rdp_accountant = rdp_privacy_accountant.RdpAccountant()
-    for mechanism, noise_parameter in zip(mechanisms, noise_parameters):
+    for mechanism, noise_parameter, n, p in zip(mechanisms, noise_parameters,
+                                                num_compositions,
+                                                sampling_probability):
         if mechanism == 'gaussian':
             event = dp_event.PoissonSampledDpEvent(
-                sampling_probability,
-                dp_event.GaussianDpEvent(noise_parameter))
+                p, dp_event.GaussianDpEvent(noise_parameter))
 
         elif mechanism == 'laplace':
             event = dp_event.LaplaceDpEvent(noise_parameter)
@@ -125,33 +145,72 @@ def get_expected_delta_rdp(noise_parameters, sampling_probability,
                 f'Mechanism {mechanism} is not supported for PRV accountant')
 
         rdp_accountant = rdp_privacy_accountant.RdpAccountant().compose(
-            event, int(num_compositions))
+            event, int(n))
 
         rdps.append(rdp_accountant)
 
-        full_rdp_accountant = full_rdp_accountant.compose(
-            event, int(num_compositions))
+        full_rdp_accountant = full_rdp_accountant.compose(event, int(n))
 
     expected_delta = full_rdp_accountant.get_delta(epsilon)
     return expected_delta, rdps
 
 
+def get_expected_delta_multiple_accountants(noise_parameters,
+                                            sampling_probability,
+                                            num_compositions, mechanisms,
+                                            epsilon, accountants,
+                                            mechanism_epsilons):
+
+    if not isinstance(sampling_probability, list):
+        sampling_probability = [sampling_probability] * len(mechanisms)
+    if not isinstance(num_compositions, list):
+        num_compositions = [num_compositions] * len(mechanisms)
+
+    expected_delta_mapping = {
+        PLDPrivacyAccountant: get_expected_delta_pld,
+        PRVPrivacyAccountant: get_expected_delta_prv,
+        RDPPrivacyAccountant: get_expected_delta_rdp
+    }
+
+    delta_sum = 0
+    for accountant_cls, sigma, p, n, mechanism, mechanism_epsilon in zip(
+            accountants, noise_parameters, sampling_probability,
+            num_compositions, mechanisms, mechanism_epsilons):
+        expected_delta_fn = expected_delta_mapping[accountant_cls]
+        delta_sum += expected_delta_fn([sigma], p, n, [mechanism],
+                                       mechanism_epsilon, None, None)[0]
+
+    return delta_sum, None
+
+
 class TestPrivacyAccountants:
 
     @pytest.mark.parametrize(
-        'accountant_class, fn_expected_delta, max_bound',
-        [(JointPLDPrivacyAccountant, get_expected_delta_pld, 20),
-         (JointPRVPrivacyAccountant, get_expected_delta_prv, 20),
-         (JointRDPPrivacyAccountant, get_expected_delta_rdp, 20)])
+        'accountants, fn_expected_delta, max_bound',
+        [(PLDPrivacyAccountant, get_expected_delta_pld, 5),
+         (PRVPrivacyAccountant, get_expected_delta_prv, 5),
+         (RDPPrivacyAccountant, get_expected_delta_rdp, 5),
+         ([PLDPrivacyAccountant, PRVPrivacyAccountant
+           ], get_expected_delta_multiple_accountants, 5)])
     @pytest.mark.parametrize(
-        'num_compositions, sampling_probability, epsilon, delta, noise_parameters, noise_scale, mechanisms, budget_proportions',  # pylint: disable=line-too-long
-        [(1000, 0.01, 2, None, [0.76, 1], 1.0, ['gaussian', 'gaussian'], None),
-         (100, 0.1, None, 1e-8, [1, 1.5], 0.5, ['laplace', 'gaussian'], None),
-         (100, 0.1, 2, 1e-8, None, 0.8, ['gaussian', 'gaussian'], [0.25, 0.75])
-         ])
+        'num_compositions, sampling_probability, epsilon, delta, mechanism_epsilons, mechanism_deltas, noise_parameters, noise_scale, mechanisms, budget_proportions',
+        [(1000, 0.01, 2, None, None, None, [0.76, 1], 1.0,
+          ['gaussian', 'gaussian'], None),
+         ([10, 100], [0.1, 0.1], None, 1e-8, None, None, [1, 1.5], 0.5,
+          ['laplace', 'gaussian'], None),
+         ([1000, 100], [0.01, 0.01], None, 1e-8, [0.5, 0.25], [2e-8, 2e-8],
+          None, 0.5, ['gaussian', 'gaussian'], None),
+         ([1000, 100], [0.01, 0.1], 2, 1e-8, None, None, None, 0.8,
+          ['gaussian', 'gaussian'], [0.25, 0.75])])
     def test(self, num_compositions, sampling_probability, epsilon, delta,
-             noise_parameters, noise_scale, mechanisms, budget_proportions,
-             accountant_class, fn_expected_delta, max_bound):
+             mechanism_epsilons, mechanism_deltas, noise_parameters,
+             noise_scale, mechanisms, budget_proportions, accountants,
+             fn_expected_delta, max_bound):
+
+        if isinstance(accountants, list) and mechanism_epsilons is not None:
+            # In the different accountants case with mechanism epsilons and deltas
+            # We need delta to be None to compute epsilon and delta by summing
+            delta = None
         # these are patches for hyperparameters for the binary search for the
         # noise parameter - these settings speed up the binary search for tests
         with patch(
@@ -169,78 +228,107 @@ class TestPrivacyAccountants:
                     new=0.1), patch(
                         'pfl.privacy.joint_privacy_accountant.RTOL_EPSILON',
                         new=0.1):
-                accountant = accountant_class(
+                joint_accountant = JointPrivacyAccountant(
+                    mechanisms=mechanisms,
+                    accountants=accountants,
                     num_compositions=num_compositions,
                     sampling_probability=sampling_probability,
-                    mechanisms=mechanisms,
-                    epsilon=epsilon,
-                    delta=delta,
+                    total_epsilon=epsilon,
+                    total_delta=delta,
+                    mechanism_epsilons=mechanism_epsilons,
+                    mechanism_deltas=mechanism_deltas,
                     budget_proportions=budget_proportions,
                     noise_parameters=noise_parameters,
                     noise_scale=noise_scale)
                 noise_parameters = ([
                     cohort_noise_parameter / noise_scale
                     for cohort_noise_parameter in
-                    accountant.cohort_noise_parameters
+                    joint_accountant.cohort_noise_parameters
                 ])
 
                 expected_delta, mechanism_accountants = fn_expected_delta(
                     noise_parameters, sampling_probability, num_compositions,
-                    mechanisms, accountant.epsilon)
+                    mechanisms, joint_accountant.total_epsilon, accountants,
+                    joint_accountant.mechanism_epsilons)
 
-                np.testing.assert_almost_equal(accountant.delta,
-                                               expected_delta)
+                np.testing.assert_almost_equal(
+                    joint_accountant.total_delta,
+                    expected_delta,
+                    err_msg=f'{joint_accountant.total_delta} {expected_delta}')
 
                 if budget_proportions:
-                    if accountant_class is JointPLDPrivacyAccountant:
+                    if accountants is PLDPrivacyAccountant:
                         for acc, p in zip(mechanism_accountants,
                                           budget_proportions):
                             np.testing.assert_almost_equal(
-                                acc.get_epsilon_for_delta(delta),
-                                accountant.large_epsilon * p,
+                                acc.get_epsilon_for_delta(delta * p),
+                                joint_accountant.naive_epsilon * p,
                                 decimal=2)
-                    elif accountant_class is JointPRVPrivacyAccountant:
-                        for acc, p in zip(mechanism_accountants,
-                                          budget_proportions):
+                    elif accountants is PRVPrivacyAccountant:
+                        for acc, p, n in zip(mechanism_accountants,
+                                             budget_proportions,
+                                             num_compositions):
                             np.testing.assert_almost_equal(
-                                acc.compute_epsilon(delta,
-                                                    [num_compositions])[1],
-                                accountant.large_epsilon * p,
+                                acc.compute_epsilon(delta * p, [n])[1],
+                                joint_accountant.naive_epsilon * p,
                                 decimal=2)
-                    elif accountant_class is JointRDPPrivacyAccountant:
+                    elif accountants is RDPPrivacyAccountant:
                         for acc, p in zip(mechanism_accountants,
                                           budget_proportions):
                             np.testing.assert_almost_equal(
-                                acc.get_epsilon(delta),
-                                accountant.large_epsilon * p,
+                                acc.get_epsilon(delta * p),
+                                joint_accountant.naive_epsilon * p,
                                 decimal=2)
 
     @pytest.mark.xfail(raises=(ValueError, AssertionError), strict=True)
-    @pytest.mark.parametrize('accountant_class', [
-        JointPLDPrivacyAccountant, JointPRVPrivacyAccountant,
-        JointRDPPrivacyAccountant
-    ])
     @pytest.mark.parametrize(
-        'num_compositions, sampling_probability, epsilon, delta, noise_parameters, noise_scale, mechanisms, budget_proportions',  # pylint: disable=line-too-long
-        [(100, 0.1, 2, None, None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
-         (100, 0.1, None, None, None, 1.0, ['gaussian', 'gaussian'
-                                            ], [0.5, 0.5]),
-         (100, 0.1, 2, 1e-8, None, 1.2, ['gaussian', 'gaussian'], [0.5, 0.5]),
-         (100, 0.1, 2, 1e-8, None, 1.0, ['bernoulli', 'gaussian'], [0.5, 0.5]),
-         (100, 0.1, 2, 1e-8, [10, 10], 1.0, ['gaussian', 'gaussian'
-                                             ], [0.5, 0.5]),
-         (100, 0.1, 2, 1e-8, None, 0.8, ['gaussian', 'gaussian'], [0.1, 0.75]),
-         (100, 0.1, 2, 1e-8, None, 0.8, ['gaussian', 'gaussian'], [1.1, 0.75])
-         ])
+        'accountants, num_compositions, sampling_probability, epsilon, delta, mechanism_epsilons, mechanism_deltas, noise_parameters, noise_scale, mechanisms, budget_proportions',
+        [
+            (PLDPrivacyAccountant, 100, 0.1, 2, None, None, None, None, 1.0,
+             ['gaussian', 'gaussian'], [0.5, 0.5]),
+            (PRVPrivacyAccountant, 100, 0.1, None, None, None, None, None, 1.0,
+             ['gaussian', 'gaussian'], [0.5, 0.5]),
+            (RDPPrivacyAccountant, 100, 0.1, 2, 1e-8, None, None, None, 1.2,
+             ['gaussian', 'gaussian'], [0.5, 0.5]),
+            (PLDPrivacyAccountant, 100, 0.1, 2, 1e-8, None, None, None, 1.0,
+             ['bernoulli', 'gaussian'], [0.5, 0.5]),
+            (PLDPrivacyAccountant, 100, 0.1, 2, 1e-8, None, None, [10, 10],
+             1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+            (PLDPrivacyAccountant, 100, 0.1, 2, 1e-8, None, None, None, 0.8,
+             ['gaussian', 'gaussian'], [0.1, 0.75]),
+            (PLDPrivacyAccountant, 100, 0.1, 2, 1e-8, None, None, None, 0.8,
+             ['gaussian', 'gaussian'], [1.1, 0.75]),
+            (PLDPrivacyAccountant, 100, 0.1, 2, None, [1, 1], None, None, 1.0,
+             ['gaussian', 'gaussian'], [0.5, 0.5]),
+            (PLDPrivacyAccountant, 100, 0.1, None, None, [1, 1], [1e-8, 1e-8],
+             None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+            (PLDPrivacyAccountant, 100, 0.1, 2, 1e-8, [1, 1], [1e-8, 1e-8],
+             None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+            (PLDPrivacyAccountant, 100, 0.1, 2, None, [1, 1], [1e-8, 1e-8],
+             [10, 10], 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+            ([PLDPrivacyAccountant, PRVPrivacyAccountant], 100, 0.1, 2, None,
+             None, None, None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+            ([PLDPrivacyAccountant, PRVPrivacyAccountant], 100, 0.1, None,
+             None, None, None, None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5
+                                                                     ]),
+            ([PLDPrivacyAccountant, PRVPrivacyAccountant], 100, 0.1, 2, 1e-8,
+             None, None, [10, 10], 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+            ([PLDPrivacyAccountant, PRVPrivacyAccountant], 100, 0.1, 2, 1e-8, [
+                1, 2
+            ], [1e-8, 1e-8], None, 1.0, ['gaussian', 'gaussian'], [0.5, 0.5]),
+        ])
     def test_fail(self, num_compositions, sampling_probability, epsilon, delta,
-                  noise_parameters, noise_scale, mechanisms,
-                  budget_proportions, accountant_class):
-        accountant_class(
+                  mechanism_epsilons, mechanism_deltas, noise_parameters,
+                  noise_scale, mechanisms, budget_proportions, accountants):
+        JointPrivacyAccountant(
+            mechanisms=mechanisms,
+            accountants=accountants,
             num_compositions=num_compositions,
             sampling_probability=sampling_probability,
-            mechanisms=mechanisms,
-            epsilon=epsilon,
-            delta=delta,
+            total_epsilon=epsilon,
+            total_delta=delta,
+            mechanism_epsilons=mechanism_epsilons,
+            mechanism_deltas=mechanism_deltas,
             budget_proportions=budget_proportions,
             noise_parameters=noise_parameters,
             noise_scale=noise_scale,


### PR DESCRIPTION
The goal of this PR is to allow initializing multiple mechanisms when they are to be applied simultaneously with a single total privacy budget, usage will be with the JointMechanism class.

When the total (epsilon, delta) budget has been provided we compute the noise parameter for each mechanism as follows: 
Suppose we have two mechanisms [M1, M2] (self composed over n steps). The user provides a list budget_proportions [p1, p2], which gives the proportion of the total budget each mechanism is allocated. We then find large_epsilon and noise parameters [s1, s2] such that
1. M1 (with noise s1) is (large_epsilon*p1, delta) DP
2. M2 (with noise s2) is (large_epsilon*p2, delta) DP
3.  The composition of M1 (with noise s1) and M2 (with noise s2) is (epsilon, delta) DP

This is done in practice with (nested) binary searches, the outer for large_epsilon and the inner for the noise parameters s1 and s2.