### PR TITLE
bugfix for print ElementWeightedMappedVectorStatistics & hyperparams inside hyperparams

### DIFF
--- a/pfl/hyperparam/base.py
+++ b/pfl/hyperparam/base.py
@@ -69,6 +69,8 @@ def get_param_value(parameter):
     """
     if isinstance(parameter, HyperParam):
         return parameter.value()
+    elif isinstance(parameter, HyperParams):
+        return parameter.static_clone()
     else:
         return parameter
 

--- a/pfl/stats.py
+++ b/pfl/stats.py
@@ -402,6 +402,9 @@ class ElementWeightedMappedVectorStatistics(MappedVectorStatistics[Tensor]):
                 f'Shape mismatch for key {key}! Shape: {this[key].shape} v.s. Shape: {other[key].shape}'
             )
 
+    def __repr__(self):
+        return f"ElementWeightedMappedVectorStatistics(weights={self.weights} data={self._data})"
+
     @property
     def weight(self) -> float:
         raise NotImplementedError


### PR DESCRIPTION
printing ElementWeightedMappedVectorStatistics throwed notimplemented.
change in pfl/hyperparam/base.py allows for HyperParams config inside another HyperParams