### PR TITLE
Update FederatedDataset docstring with location of user sampler.

### DIFF
--- a/pfl/data/federated_dataset.py
+++ b/pfl/data/federated_dataset.py
@@ -329,7 +329,7 @@ class FederatedDataset(FederatedDatasetBase):
         In most cases you want to use `MinimizeReuseUserSampler` because its
         behaviour mimics what usually happens in live federated learning with
         user devices.
-        See `MinimizeReuseUserSampler` for explanation why.
+        See `pfl.data.sampling.MinimizeReuseUserSampler` for explanation why.
 
         The factory called `get_user_sampler` provides some examples of how this
         callable might look like.


### PR DESCRIPTION
Update FederatedDataset docstring with location of user sampler. A user might see 'MinimizeReuseUserSampler' and not know where it's located in the pfl lib. To make this easier for the user, the docstring could refer to `pfl.data.sampling.MinimizeReuseUserSampler` in the final comment.