### PR TITLE
Fix FederatedGBDT Stop Condition

### DIFF
--- a/pfl/tree/federated_gbdt.py
+++ b/pfl/tree/federated_gbdt.py
@@ -622,8 +622,10 @@ class FederatedGBDT(FederatedAlgorithm[GBDTAlgorithmHyperParamsType,
             self._finish_tree_id = (model.current_tree +
                                     algorithm_params.num_trees)
 
-        # stop condition
-        if model.current_tree > self._finish_tree_id:
+        # stop condition: use >= so that exactly num_trees trees are trained.
+        # When current_depth == 0, current_tree == len(trees), so >= stops
+        # as soon as the target number of trees have been completed.
+        if model.current_tree >= self._finish_tree_id:
             return None, model, Metrics()
 
         # train cohort size

--- a/tests/tree/test_federated_gbdt.py
+++ b/tests/tree/test_federated_gbdt.py
@@ -656,7 +656,7 @@ class TestFederatedGBDT:
                                    callbacks=[])
 
         # pylint: disable=protected-access
-        assert model.current_tree == gbdt_algorithm_params.num_trees + 1
+        assert model.current_tree == gbdt_algorithm_params.num_trees
 
     @pytest.mark.parametrize(
         'model',
@@ -665,6 +665,12 @@ class TestFederatedGBDT:
     def test_get_next_central_contexts(self, gbdt_algorithm, model,
                                        gbdt_algorithm_params,
                                        gbdt_regression_model_hyper_params):
+        # Run iteration 0 to set gbdt_algorithm._finish_tree_id
+        gbdt_algorithm.get_next_central_contexts(
+            model, 0, gbdt_algorithm_params,
+            gbdt_regression_model_hyper_params,
+            gbdt_regression_model_hyper_params)
+
         iteration = 1
         (configs, output_model,
          metrics) = (gbdt_algorithm.get_next_central_contexts(


### PR DESCRIPTION
Currently the stop condition will create more trees than the `num_trees` in the algorithm params. This PR fix the stopping condition of FederatedGBDT